### PR TITLE
Fixes Excessive Kaiser Spit Puddle Stacking and Makes Them More Obvious

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/misc.dm
+++ b/code/game/objects/effects/decals/Cleanable/misc.dm
@@ -36,7 +36,7 @@
 	. = ..()
 	for(var/mob/living/carbon/l in range(4))
 		if(prob(25))
-			to_chat(src, SPAN_WARNING("The air begins to feel warm."))
+			to_chat(src, SPAN_WARNING("The air begins to feel warm, accompanied by a hideous aroma."))	//Equinox edit: makes the danger more obvious
 		l.apply_effect(0.5, IRRADIATE) //we spit out THREE of these.
 
 /obj/effect/decal/cleanable/dirt
@@ -144,7 +144,9 @@
 
 /obj/effect/decal/cleanable/greenglow/bile
 	name = "glowing bile"
-	desc = "A small puddle of glowing green bile, it utterly reeks. Just being near it makes you feel a bit warmer."
+	desc = "A small puddle of glowing green bile, it utterly reeks. Just being near it makes you feel a bit warmer. It appears to be highly volatile and is slowly evaporating away." //Equinox edit: Less hidden mechanics, more documented information
+	icon = 'icons/effects/effects.dmi'		//Equinox edit: Changes the icon to be a lot more obvious
+	icon_state = "toxic_puddle"
 
 
 /obj/effect/decal/cleanable/slimecorpse // Slimepeople remains

--- a/code/modules/mob/living/carbon/superior_animal/roach/roach_spits.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/roach_spits.dm
@@ -31,7 +31,8 @@
 
 /obj/item/projectile/roach_spit/large/on_hit(atom/target)
 	. = ..()
-	new /obj/effect/decal/cleanable/greenglow/bile(src.loc)
+	if(!(locate(/obj/effect/decal/cleanable/greenglow/bile) in target.loc))		//Equinox edit: Prevents excessive stacking of hundreds of puddles that process and irradiate
+		new /obj/effect/decal/cleanable/greenglow/bile(target.loc)		//Equinox edit: Makes the puddles drop right on the intended target instead of harmlessly splatering on distant walls
 	if(isliving(target))
 		if (!testing)
 			var/mob/living/L = target


### PR DESCRIPTION

## About The Pull Request
Currently, Kaiser's ranged attack has some janky interactions that causes it to stack up an excessive amount of radioactive puddles that process() and scan for mobs within 4 tiles to irradiate. This is rather bad for server performance, and has a tendency to cause exponentially more radiation than even the Kaiser's melee attacks. Furthermore, the puddles are not even placed on the targeted victim, and tend to pool around walls off in the distance.

This PR prevents the puddles from stacking up more than once in a single tile, makes them more obvious with a different sprite, and also makes them land on the intended target instead of causing weird collateral. In addition, the description of the puddle has been amended to clarify that it will eventually delete itself. (after 120 seconds)

![dreamseeker_T7VJVNgr5W](https://github.com/user-attachments/assets/984ee6e0-ee98-4eef-8103-b38f877a354e)


## Changelog
:cl: Toriate
fix: Kaiser spit puddles will no longer stack excessively and are more obvious
/:cl:
