### PR TITLE
Ports Runechat (with slight tweak)

### DIFF
--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -176,7 +176,7 @@ var/list/_client_preferences_by_type
 /datum/client_preference/floating_messages
 	description ="Floating chat messages"
 	key = "FLOATING_CHAT"
-	options = list(GLOB.PREF_HIDE, GLOB.PREF_SHOW)
+	options = list(GLOB.PREF_SHOW, GLOB.PREF_HIDE)
 
 /datum/client_preference/browser_style
 	description = "Fake NanoUI Browser Style"

--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -173,10 +173,16 @@ var/list/_client_preferences_by_type
 	key = "SHOW_PROGRESS"
 	options = list(GLOB.PREF_SHOW, GLOB.PREF_HIDE)
 
+/datum/client_preference/floating_messages
+	description ="Floating chat messages"
+	key = "FLOATING_CHAT"
+	options = list(GLOB.PREF_HIDE, GLOB.PREF_SHOW)
+
 /datum/client_preference/browser_style
 	description = "Fake NanoUI Browser Style"
 	key = "BROWSER_STYLED"
 	options = list(GLOB.PREF_FANCY, GLOB.PREF_PLAIN)
+
 /*
 /datum/client_preference/autohiss
 	description = "Autohiss"

--- a/code/modules/mob/floating_say.dm
+++ b/code/modules/mob/floating_say.dm
@@ -1,0 +1,67 @@
+// Thanks to Burger from Burgerstation for the foundation for this.
+// This code was written by Chinsky for Nebula, I just made it compatible with Eris. - Matt
+GLOBAL_LIST_INIT(floating_chat_colors, list())
+
+/atom/movable
+	var/list/stored_chat_text
+
+/atom/movable/proc/animate_chat(message, datum/language/language, small, list/show_to, duration)
+	set waitfor = FALSE
+
+	var/style	//additional style params for the message
+	var/fontsize = 6
+	if(small)
+		fontsize = 5
+	var/limit = 50
+	if(copytext(message, length(message) - 1) == "!!")
+		fontsize = 8
+		limit = 30
+		style += "font-weight: bold;"
+
+	if(length(message) > limit)
+		message = "[copytext(message, 1, limit)]..."
+
+	if(!GLOB.floating_chat_colors[name])
+		GLOB.floating_chat_colors[name] = get_random_colour(0,160,230)
+	style += "color: [GLOB.floating_chat_colors[name]];"
+	// create 2 messages, one that appears if you know the language, and one that appears when you don't know the language
+	var/image/understood = generate_floating_text(src, capitalize(message), style, fontsize, duration, show_to)
+	var/image/gibberish = language ? generate_floating_text(src, language.scramble(message), style, fontsize, duration, show_to) : understood
+
+	for(var/client/C in show_to)
+		if(!isdeaf(C.mob) && C.get_preference_value(/datum/client_preference/floating_messages) == GLOB.PREF_SHOW)
+			if(C.mob.say_understands(null, language))
+				C.images += understood
+			else
+				C.images += gibberish
+
+/proc/generate_floating_text(atom/movable/holder, message, style, size, duration, show_to)
+	var/image/I = image(null, holder)
+	I.layer = FLY_LAYER
+	I.alpha = 0
+	I.maptext_width = 80
+	I.maptext_height = 64
+	I.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
+	I.pixel_x = -round(I.maptext_width/2) + 16
+
+	style = "font-family: 'Small Fonts'; -dm-text-outline: 1 black; font-size: [size]px; [style]"
+	I.maptext = "<center><span style=\"[style]\">[message]</span></center>"
+	animate(I, 1, alpha = 255, pixel_y = 16)
+
+	for(var/image/old in holder.stored_chat_text)
+		animate(old, 2, pixel_y = old.pixel_y + 8)
+	LAZYADD(holder.stored_chat_text, I)
+
+	addtimer(CALLBACK(GLOBAL_PROC, .proc/remove_floating_text, holder, I), duration)
+	addtimer(CALLBACK(GLOBAL_PROC, .proc/remove_images_from_clients, I, show_to), duration + 2)
+
+	return I
+
+/proc/remove_floating_text(atom/movable/holder, image/I)
+	animate(I, 2, pixel_y = I.pixel_y + 10, alpha = 0)
+	LAZYREMOVE(holder.stored_chat_text, I)
+
+/proc/remove_images_from_clients(image/I, list/show_to)
+	for(var/client/C in show_to)
+		C.images -= I
+		qdel(I)

--- a/code/modules/mob/floating_say.dm
+++ b/code/modules/mob/floating_say.dm
@@ -46,7 +46,7 @@ GLOBAL_LIST_INIT(floating_chat_colors, list())
 
 	style = "font-family: 'Small Fonts'; -dm-text-outline: 1 black; font-size: [size]px; [style]"
 	I.maptext = "<center><span style=\"[style]\">[message]</span></center>"
-	animate(I, 1, alpha = 255, pixel_y = 16)
+	animate(I, 1, alpha = 255, pixel_y = 24)
 
 	for(var/image/old in holder.stored_chat_text)
 		animate(old, 2, pixel_y = old.pixel_y + 8)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -288,7 +288,8 @@ var/list/channel_to_radio_key = new
 			speech_bubble_recipients += M.client
 		M.hear_say(message, verb, speaking, alt_name, italics, src, speech_sound, sound_vol, 1)
 
-	animate_speechbubble(speech_bubble, speech_bubble_recipients, 30)
+	INVOKE_ASYNC(GLOBAL_PROC, .proc/animate_speechbubble, speech_bubble, speech_bubble_recipients, 30)
+	INVOKE_ASYNC(src, /atom/movable/proc/animate_chat, message, speaking, italics, speech_bubble_recipients, 40)
 
 	for(var/obj/O as anything in listening_obj)
 		spawn(0)

--- a/sojourn-station.dme
+++ b/sojourn-station.dme
@@ -2182,6 +2182,7 @@
 #include "code\modules\mob\animations.dm"
 #include "code\modules\mob\death.dm"
 #include "code\modules\mob\emote.dm"
+#include "code\modules\mob\floating_say.dm"
 #include "code\modules\mob\gender.dm"
 #include "code\modules\mob\hear_say.dm"
 #include "code\modules\mob\holder.dm"


### PR DESCRIPTION
## About The Pull Request
This PR ports over Eris' runechat and nudges the text up a little for better clarity.
![dreamseeker_SQISkxdA6h](https://github.com/user-attachments/assets/7c8b53dd-770a-4ec9-873d-49e37b3b997e) ![dreamseeker_nhmCx1hWoq](https://github.com/user-attachments/assets/3b097926-3276-4445-bf4d-6c2940f98a8c)

## Changelog
:cl: Toriate
add: Added runechat. Can be disabled in your global prefs if you hate it.
/:cl: