### PR TITLE
Adds a sanity check to prevent a genetics-related runtime that is causing CI failures

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks/meat.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/meat.dm
@@ -19,10 +19,11 @@
 
 //For initializing genetics information for meat, so it's easy to call.
 /obj/item/reagent_containers/food/snacks/meat/proc/initialize_genetics(mob/living/meat_source)
-	inherent_mutations = meat_source.inherent_mutations.Copy()
-	unnatural_mutations = meat_source.unnatural_mutations.Copy()
-	source_mob = meat_source.type
-	source_name = meat_source.name
+	if(meat_source)	//EQUINOX EDIT: basic sanity check to prevent runtimes
+		inherent_mutations = meat_source.inherent_mutations.Copy()
+		unnatural_mutations = meat_source.unnatural_mutations.Copy()
+		source_mob = meat_source.type
+		source_name = meat_source.name
 
 /obj/item/reagent_containers/food/snacks/meat/syntiflesh
 	name = "synthetic meat"


### PR DESCRIPTION
## About The Pull Request
Really shouldn't do much aside from prevent a really rare runtime that has caused CI failures.

## Changelog
:cl:
fix: fixed an edge case runtime with meat's genetics vars during map initialization
/:cl: