### PR TITLE
Fix wrong ref-cleanup order in SMES

### DIFF
--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -100,7 +100,7 @@
 
 /obj/machinery/power/smes/Destroy()
 	GLOB.smes_list -= src
-	..()
+	. = ..()
 
 /obj/machinery/power/smes/add_avail(var/amount)
 	if(..(amount))

--- a/code/modules/power/smes_construction.dm
+++ b/code/modules/power/smes_construction.dm
@@ -65,11 +65,12 @@
 	should_be_mapped = 1
 
 /obj/machinery/power/smes/buildable/Destroy()
-	qdel(wires)
-	wires = null
+	QDEL_NULL(wires)
+
+	. = ..()
+
 	for(var/datum/tgui_module/rcon/R in world)
 		R.FindDevices()
-	return ..()
 
 // Proc: process()
 // Parameters: None


### PR DESCRIPTION
## About The Pull Request

Lets see if this can help fix the infinite loop that appears when qdelling a SMES.

## Changelog
:cl:
fix: Fix SMES' references not being cleaned properly when deleted.
/:cl: