### PR TITLE
Tools no longer take maxHP damage on repair

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,7 @@ indent_size = 4
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
-end_of_line = lf
+end_of_line = crlf
 
 [*.yml]
 indent_style = space

--- a/code/game/objects/items/weapons/tools/_tools.dm
+++ b/code/game/objects/items/weapons/tools/_tools.dm
@@ -1107,9 +1107,8 @@
 					var/tool_repair = T.max_health * (0.8 + (user.stats.getStat(STAT_MEC))/200)
 					var/damage_to_repair = T.max_health - T.health
 					tool_repair = min(tool_repair, damage_to_repair)
-					var/perma_health_loss = tool_repair * 0.50 //50%
 
-					T.max_health -= perma_health_loss
+
 					T.adjustToolHealth(tool_repair, user)
 					if(user.stats.getStat(STAT_MEC) > STAT_LEVEL_BASIC/2)
 						to_chat(user, SPAN_NOTICE("You knowledge in tools helped you repair it better."))


### PR DESCRIPTION
Completely removes tool maxhp loss on repair. I don't get why this is a mechanic? Tools last at most 5 hours anyways, and getting good ones takes a lot of effort and time Being able to use them with just minor maintenance over the rest of the round seems fine from a balance perspective, and way more sensical from a RP perspective. 

Also I'm genuinely not a fan of durability mechanics in general but since you can repair somewhat easily without penalty once this is gone I think it's fine.

## Changelog
:cl:
balance: tools no longer lose maxhp on repair.
/:cl:


