### PR TITLE
nanogate rebalance: variable speedup and regen

### DIFF
--- a/code/__DEFINES/perks.dm
+++ b/code/__DEFINES/perks.dm
@@ -182,6 +182,7 @@
 #define PERK_NANITE_ARMOR /datum/perk/nanite_power/nanite_armor
 #define PERK_NANITE_AMMO /datum/perk/nanite_power/nanite_ammo
 #define PERK_NANITE_METAL_EATER /datum/perk/nanite_power/nanite_metal_drinker
+#define PERK_NANITE_MODS /datum/perk/nanite_power/nanite_mods
 
 // Crayon Mage Perks
 #define PERK_ALCHEMY /datum/perk/alchemist

--- a/code/datums/perks/nanogate.dm
+++ b/code/datums/perks/nanogate.dm
@@ -49,15 +49,15 @@
 	mesh weave shield just before a strike connects."
 	icon_state = "naniteskinweave"
 	gain_text = "You feel a dull ache as your nanogate releases newly configured nanites into your body."
+	var/max_health_adjust = 0
 
-/datum/perk/nanite_power/nanite_armor/assign(mob/living/L)
-	..()
-	holder.maxHealth += 40
-	holder.health += 40
+/datum/perk/nanite_power/nanite_armor/proc/adjustMaxHP()
+	holder.maxHealth += max_health_adjust
+	holder.health += max_health_adjust
 
 /datum/perk/nanite_power/nanite_armor/remove()
-	holder.maxHealth -= 40
-	holder.health -= 40
+	holder.maxHealth -= max_health_adjust
+	holder.health -= max_health_adjust
 	..()
 
 /datum/perk/nanite_power/nanite_metal_drinker
@@ -73,17 +73,17 @@
 	passivePerk = FALSE
 	var/chem_id = "nanites"
 	var/chem_amount = 15
-	var/anti_cheat = FALSE //Used to prevent multy stacking clicking
+	var/cooldown_amount = 15 MINUTES
 
 /datum/perk/nanite_power/nanite_chem/activate()
 	..()
-	if(anti_cheat)
-		to_chat(holder, "Something feels cold.")
-		return
-	anti_cheat = TRUE
+	if(world.time < cooldown_time)
+		to_chat(usr, SPAN_NOTICE("Your nanite reserve is still refilling, you'll need to wait longer."))
+		return FALSE
+	cooldown_time = world.time + cooldown_amount
 	to_chat(holder, "You feel a sudden rush as the pre-programed nanites enter your bloodstream.")
 	holder.reagents.add_reagent(chem_id, chem_amount)
-	spawn(20) holder.stats.removePerk(src.type) // Delete the perk
+
 
 //Unused, because this kind of nanite doesn't exist?!?!
 /datum/perk/nanite_power/nanite_chem/implantoids
@@ -124,12 +124,12 @@
 /datum/perk/nanite_power/nanite_ammo
 	name = "Munition Fabrication"
 	desc = "You programmed and set aside a specific subset of nanites whose singular purpose is to reconstruct themselves into ammunition boxes. The process is quite intensive and requires \
-	half an hour between uses."
+	fifteen minutes between uses."
 	icon_state = "munitionfabrication"
 	gain_text = "You feel a dull ache as your nanogate releases newly configured nanites into your body."
 	active = FALSE
 	passivePerk = FALSE
-	var/cooldown = 30 MINUTES
+	var/cooldown = 15 MINUTES
 	var/anti_cheat = FALSE //No more spaming...
 
 /datum/perk/nanite_power/nanite_ammo/activate()
@@ -164,8 +164,6 @@
 						/obj/item/ammo_magazine/ammobox/rifle_75_small/hv,
 						/obj/item/ammo_magazine/ammobox/rifle_75_small/scrap,
 						/obj/item/ammo_magazine/ammobox/laser_223/box,
-						//obj/item/ammo_magazine/ammobox/laser_223/box/ap,
-						//obj/item/ammo_magazine/ammobox/laser_223/box/lethal,
 						/obj/item/ammo_magazine/ammobox/kurtz_50/hv,
 						/obj/item/ammo_magazine/ammobox/kurtz_50/laser,
 						/obj/item/ammo_magazine/ammobox/antim, //Unlike the small box holds 15

--- a/code/datums/perks/nanogate.dm
+++ b/code/datums/perks/nanogate.dm
@@ -124,7 +124,7 @@
 /datum/perk/nanite_power/nanite_ammo
 	name = "Munition Fabrication"
 	desc = "You programmed and set aside a specific subset of nanites whose singular purpose is to reconstruct themselves into ammunition boxes. The process is quite intensive and requires \
-	fifteen minutes between uses."
+	up to fifteen minutes between uses."
 	icon_state = "munitionfabrication"
 	gain_text = "You feel a dull ache as your nanogate releases newly configured nanites into your body."
 	active = FALSE
@@ -203,24 +203,23 @@
 
 
 
-/datum/perk/nanite_power/nanite_ammo
-	name = "Munition Fabrication"
-	desc = "You programmed and set aside a specific subset of nanites whose singular purpose is to reconstruct themselves into ammunition boxes. The process is quite intensive and requires \
-	fifteen minutes between uses."
+/datum/perk/nanite_power/nanite_mods
+	name = "Modification Fabrication"
+	desc = "You programmed and set aside a specific subset of nanites whose singular purpose is to reconstruct themselves into tool modifications. The process is quite intensive and requires \
+	an hour between uses."
 	icon_state = "munitionfabrication"
 	gain_text = "You feel a dull ache as your nanogate releases newly configured nanites into your body."
 	active = FALSE
 	passivePerk = FALSE
-	var/cooldown = 15 MINUTES
+	var/cooldown = 60 MINUTES
 	var/anti_cheat = FALSE //No more spaming...
 
-/datum/perk/nanite_power/nanite_ammo/activate()
+/datum/perk/nanite_power/nanite_mods/activate()
 	if(world.time < cooldown_time)
-		to_chat(usr, SPAN_NOTICE("Your nanites didn't ready an ammo box yet."))
+		to_chat(usr, SPAN_NOTICE("Your nanites aren't ready to produce another modification yet."))
 		return FALSE
 
 	if(anti_cheat)
-		to_chat(holder, "Something feels cold.")
 		return
 	anti_cheat = TRUE
 	// Add illegal shit here
@@ -276,27 +275,11 @@
 
 	var/obj/item/choice = input(src, "Which modification do you want?", "Mod Choice", null) as null|anything in choice_mods
 
-	if(choice && organ.pay_power_cost(1))
-		to_chat(src, "You permanently assign some of your nanites to create a modification.")
+	if(choice)
+		to_chat(src, "You assign some of your nanites to create a modification.")
 		choice = choice_mods[choice]
 		put_in_hands(new choice(get_turf(src)))
 
-
-	var/list/ammo_boxes = list()
-	for(var/ammo in subtypesof(/obj/item/ammo_magazine/ammobox))
-		if (ammo in blacklisted_types)
-			continue
-		var/obj/O = ammo
-		ammo_boxes[initial(O.name)] = ammo
-
-	var/obj/item/choice = input(usr, "Which type of ammo do you want?", "Ammo Choice", null) as null|anything in ammo_boxes
-
-	if (!choice)	// user can cancel
-		anti_cheat = FALSE
-		return
-
-	choice = ammo_boxes[choice]
-	usr.put_in_hands(new choice(get_turf(usr)))
 	cooldown_time = world.time + cooldown
 
 	anti_cheat = FALSE

--- a/code/datums/perks/nanogate.dm
+++ b/code/datums/perks/nanogate.dm
@@ -200,3 +200,104 @@
 
 	anti_cheat = FALSE
 	return ..()
+
+
+
+/datum/perk/nanite_power/nanite_ammo
+	name = "Munition Fabrication"
+	desc = "You programmed and set aside a specific subset of nanites whose singular purpose is to reconstruct themselves into ammunition boxes. The process is quite intensive and requires \
+	fifteen minutes between uses."
+	icon_state = "munitionfabrication"
+	gain_text = "You feel a dull ache as your nanogate releases newly configured nanites into your body."
+	active = FALSE
+	passivePerk = FALSE
+	var/cooldown = 15 MINUTES
+	var/anti_cheat = FALSE //No more spaming...
+
+/datum/perk/nanite_power/nanite_ammo/activate()
+	if(world.time < cooldown_time)
+		to_chat(usr, SPAN_NOTICE("Your nanites didn't ready an ammo box yet."))
+		return FALSE
+
+	if(anti_cheat)
+		to_chat(holder, "Something feels cold.")
+		return
+	anti_cheat = TRUE
+	// Add illegal shit here
+	var/list/blacklisted_types = list(	/obj/item/tool_upgrade/reinforcement,
+						/obj/item/tool_upgrade/productivity,
+						/obj/item/tool_upgrade/refinement,
+						/obj/item/tool_upgrade/augment,
+						/obj/item/tool_upgrade/armor,
+						/obj/item/tool_upgrade/augment/holding_tank,
+						/obj/item/tool_upgrade/augment/ai_tool,
+						/obj/item/tool_upgrade/augment/ai_tool_excelsior,
+						/obj/item/tool_upgrade/augment/repair_nano,
+						/obj/item/tool_upgrade/augment/randomizer,
+						/obj/item/tool_upgrade/augment/holy_oils,
+						/obj/item/tool_upgrade/augment/crusader_seal,
+						/obj/item/tool_upgrade/artwork_tool_mod,
+						/obj/item/tool_upgrade/augment/sanctifier,	//Has biomatter, sadly nanites are not able to use that
+						/obj/item/gun_upgrade/barrel,
+						/obj/item/gun_upgrade/muzzle,
+						/obj/item/gun_upgrade/mechanism,
+						/obj/item/gun_upgrade/trigger,
+						/obj/item/gun_upgrade/magwell,
+						/obj/item/gun_upgrade/scope,
+						/obj/item/gun_upgrade/underbarrel,
+						/obj/item/gun_upgrade/barrel/forged,
+						/obj/item/gun_upgrade/barrel/bore,
+						/obj/item/gun_upgrade/barrel/excruciator,	//Sadly has biomatter
+						/obj/item/gun_upgrade/mechanism/upgrade_kit,
+						/obj/item/gun_upgrade/mechanism/clock_block,//Brass and unknown tech
+						/obj/item/gun_upgrade/trigger/boom,			//Illegal
+						/obj/item/gun_upgrade/scope/watchman,
+						/obj/item/gun_upgrade/mechanism/glass_widow,
+						/obj/item/gun_upgrade/mechanism/greyson_master_catalyst,
+						/obj/item/gun_upgrade/mechanism/brass_kit,
+						/obj/item/gun_upgrade/trigger/honker,
+						/obj/item/gun_upgrade/mechanism/bikehorn,
+						/obj/item/gun_upgrade/mechanism/faulty_trapped,
+						/obj/item/gun_upgrade/trigger/faulty,
+						/obj/item/gun_upgrade/barrel/faulty,
+						/obj/item/gun_upgrade/muzzle/faulty,
+						/obj/item/gun_upgrade/mechanism/faulty,
+						/obj/item/gun_upgrade/scope/faulty
+	)
+
+	var/list/choice_mods = list()
+	// add new paths into the format of + subtypesof(XXX)
+	var/list/types = subtypesof(/obj/item/tool_upgrade) + subtypesof(/obj/item/gun_upgrade)
+	for (var/mod in types)
+		if (mod in blacklisted_types)
+			continue
+		var/obj/O = mod
+		choice_mods[initial(O.name)] = mod
+
+	var/obj/item/choice = input(src, "Which modification do you want?", "Mod Choice", null) as null|anything in choice_mods
+
+	if(choice && organ.pay_power_cost(1))
+		to_chat(src, "You permanently assign some of your nanites to create a modification.")
+		choice = choice_mods[choice]
+		put_in_hands(new choice(get_turf(src)))
+
+
+	var/list/ammo_boxes = list()
+	for(var/ammo in subtypesof(/obj/item/ammo_magazine/ammobox))
+		if (ammo in blacklisted_types)
+			continue
+		var/obj/O = ammo
+		ammo_boxes[initial(O.name)] = ammo
+
+	var/obj/item/choice = input(usr, "Which type of ammo do you want?", "Ammo Choice", null) as null|anything in ammo_boxes
+
+	if (!choice)	// user can cancel
+		anti_cheat = FALSE
+		return
+
+	choice = ammo_boxes[choice]
+	usr.put_in_hands(new choice(get_turf(usr)))
+	cooldown_time = world.time + cooldown
+
+	anti_cheat = FALSE
+	return ..()

--- a/code/datums/perks/nanogate.dm
+++ b/code/datums/perks/nanogate.dm
@@ -14,7 +14,7 @@
 	desc = "You configure your nanite matrix to begin aiding in your natural healing."
 	icon_state = "naniteregeneration"
 	gain_text = "You feel a dull ache as your nanogate releases newly configured nanites into your body."
-	var/regen_rate = 0.5 //This seems low but this is per human handle_chemicals_in_body meaning this is rather robust
+	var/regen_rate = 0.7 //This seems low but this is per human handle_chemicals_in_body meaning this is rather robust
 	emped_message = "You feel an uncomfortable tingling numbness throughout your entire body, like a limb that has just gone to sleep."
 	emped_end_message = "The tingling stops as your nanogate informs you that it has restored its regenerative nanites."
 
@@ -36,6 +36,7 @@
 	gain_text = "You feel a dull ache as your nanogate releases newly configured nanites into your body."
 	emped_message = "You feel your legs cramp as your nanite-augmented muscles seize."
 	emped_end_message = "The pain in your legs fades as mobility returns to your muscles."
+	var/speedup = 0.3
 
 /datum/perk/nanite_power/nanite_muscle/on_emp(nano, severity)
 	if(severity) //Let's NOT divide by any zeroes!

--- a/code/datums/perks/nanogate.dm
+++ b/code/datums/perks/nanogate.dm
@@ -278,7 +278,7 @@
 	if(choice)
 		to_chat(src, "You assign some of your nanites to create a modification.")
 		choice = choice_mods[choice]
-		put_in_hands(new choice(get_turf(src)))
+		usr.put_in_hands(new choice(get_turf(src)))
 
 	cooldown_time = world.time + cooldown
 

--- a/code/datums/perks/nanogate.dm
+++ b/code/datums/perks/nanogate.dm
@@ -273,14 +273,13 @@
 		var/obj/O = mod
 		choice_mods[initial(O.name)] = mod
 
-	var/obj/item/choice = input(src, "Which modification do you want?", "Mod Choice", null) as null|anything in choice_mods
+	var/obj/item/choice = input(usr, "Which modification do you want?", "Mod Choice", null) as null|anything in choice_mods
 
 	if(choice)
 		to_chat(src, "You assign some of your nanites to create a modification.")
 		choice = choice_mods[choice]
 		usr.put_in_hands(new choice(get_turf(src)))
-
-	cooldown_time = world.time + cooldown
+		cooldown_time = world.time + cooldown
 
 	anti_cheat = FALSE
 	return ..()

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -22,7 +22,7 @@
 	if(stats.getPerk(PERK_NANITE_MUSCLE))
 		var/datum/perk/nanite_power/nanite_muscle/P = stats.getPerk(PERK_NANITE_MUSCLE)
 		if(!P.emped)
-			tally -= 0.3
+			tally -= P.speedup
 	if(stats.getPerk(PERK_SCUTTLEBUG))
 		tally -= 0.3
 	if(stats.getPerk(PERK_REZ_SICKNESS))

--- a/code/modules/nanogate/powers/user.dm
+++ b/code/modules/nanogate/powers/user.dm
@@ -1,9 +1,9 @@
 // The powers here are centered around upgrading the user.
 /*
 List of powers in this page :
-- Regeneration : Give the user a perk that constantly heal himself at a very slow rate defined in the perk itself.
-- Speed Booster : Give the user a perk that make him move faster, the speed increase being defined in the perk itself.
-- Armor Upgrade : Give the user a perk that reduce damage, again the precise number is defined in the perk given.
+- Regeneration : Give the user a perk that constantly heal himself at a very slow rate based on the amount of points spent
+- Speed Booster : Give the user a perk that make him move faster, the speed increase based on the amount of points spent
+- Armor Upgrade : Give the user a perk that increases max hp, again the precise number is defined in the perk given.
 - Chemical Injection : Allow the user to choose a type of nanite chem to inject himself, then give him a perk that will do the injection when the user want.
 - Tool/Gun Mods : Give the user a modification that they chose from a list. The only reusable power.
 - Nanite Ammo : Give the user a perk that can spawn an ammo box of a specified type every 30 minutes. Delay defined in the perk itself.
@@ -12,17 +12,23 @@ List of powers in this page :
 // Give the user a perk that constantly heal a tiny bit of damage.
 /mob/living/carbon/human/proc/nanite_regen()
 	set category = "Nanogate Powers"
-	set name = "Nanite Regeneration (7)"
-	set desc = "Spend a large portion of your nanites to restore and repair your body by enhancing your natural healing."
+	set name = "Nanite Regeneration" //0.1hp/tick per nanite point
+	set desc = "Spend a variable portion of your nanites to restore and repair your body by enhancing your natural healing."
 
 	var/obj/item/organ/internal/nanogate/organ = first_organ_by_type(/obj/item/organ/internal/nanogate)
 	if(!organ)
 		return
 
-	if(!stats.getPerk(PERK_NANITE_REGEN)) // Do they already have the bot?
-		if(organ.pay_power_cost(7))
+	if(!stats.getPerk(PERK_NANITE_REGEN)) // Do they already have the perk?
+		var/variable_cost = input("How many points would you like to spend on nanite regeneration? (0.1hp/tick per point, max of 10)", "Assign nanites") as null|num
+		if((variable_cost > 10) || (variable_cost < 1))
+			to_chat(src, "Invalid nanite amount!")
+			return
+		if(organ.pay_power_cost(variable_cost))
 			to_chat(src, "You permanently assign some of your nanites to repairing your body.")
 			stats.addPerk(PERK_NANITE_REGEN)
+			var/datum/perk/nanite_power/nanite_regen/NR = stats.getPerk(PERK_NANITE_REGEN)
+			NR.regen_rate = variable_cost * 0.1
 			organ.organ_remove_verb(/mob/living/carbon/human/proc/nanite_regen)
 	else
 		to_chat(src, "Assigning more nanites to repairing your body wouldn't give you a boost in regeneration rate.")
@@ -30,17 +36,23 @@ List of powers in this page :
 // Give the user a perk that make him move faster
 /mob/living/carbon/human/proc/nanite_muscle()
 	set category = "Nanogate Powers"
-	set name = "Nanite Augment - Nanofiber Muscles (5)"
-	set desc = "Spend some of your nanites to create nanite muscle to allow you to move faster."
+	set name = "Nanite Augment - Nanofiber Muscles" //0.06speedup per nanite point
+	set desc = "Spend a variable amount of your nanites to create nanite muscle to allow you to move faster."
 
 	var/obj/item/organ/internal/nanogate/organ = first_organ_by_type(/obj/item/organ/internal/nanogate)
 	if(!organ)
 		return
 
 	if(!stats.getPerk(PERK_NANITE_MUSCLE)) // Do they already have the perk?
-		if(organ.pay_power_cost(5))
+		var/variable_cost = input("How many points would you like to spend on nanofiber musculuature? (0.06 speedup per point, max of 10)", "Assign nanites") as null|num
+		if((variable_cost > 10) || (variable_cost < 1))
+			to_chat(src, "Invalid nanite amount!")
+			return
+		if(organ.pay_power_cost(variable_cost))
 			to_chat(src, "You permanently assign some of your nanites to enhancing your physical movement.")
 			stats.addPerk(PERK_NANITE_MUSCLE)
+			var/datum/perk/nanite_power/nanite_muscle/NM = stats.getPerk(PERK_NANITE_MUSCLE)
+			NM.regen_rate = variable_cost * 0.1
 			organ.organ_remove_verb(/mob/living/carbon/human/proc/nanite_muscle)
 	else
 		to_chat(src, "Assigning more nanites to enhance your muscles wouldn't offer any benefit.")
@@ -49,7 +61,7 @@ List of powers in this page :
 /mob/living/carbon/human/proc/nanite_armor()
 	set category = "Nanogate Powers"
 	set name = "Nanite Augment - Nanite Skin-Weave (3)"
-	set desc = "Spend some of your nanites to create nanite weave mesh to protect your body."
+	set desc = "Spend a variable amount of your nanites to create subdermal nanite weave to protect your body."
 
 	var/obj/item/organ/internal/nanogate/organ = first_organ_by_type(/obj/item/organ/internal/nanogate)
 	if(!organ)

--- a/code/modules/nanogate/powers/user.dm
+++ b/code/modules/nanogate/powers/user.dm
@@ -127,63 +127,6 @@ List of powers in this page :
 	if(!organ)
 		return
 
-		// Add illegal shit here
-	var/list/blacklisted_types = list(	/obj/item/tool_upgrade/reinforcement,
-						/obj/item/tool_upgrade/productivity,
-						/obj/item/tool_upgrade/refinement,
-						/obj/item/tool_upgrade/augment,
-						/obj/item/tool_upgrade/armor,
-						/obj/item/tool_upgrade/augment/holding_tank,
-						/obj/item/tool_upgrade/augment/ai_tool,
-						/obj/item/tool_upgrade/augment/ai_tool_excelsior,
-						/obj/item/tool_upgrade/augment/repair_nano,
-						/obj/item/tool_upgrade/augment/randomizer,
-						/obj/item/tool_upgrade/augment/holy_oils,
-						/obj/item/tool_upgrade/augment/crusader_seal,
-						/obj/item/tool_upgrade/artwork_tool_mod,
-						/obj/item/tool_upgrade/augment/sanctifier,	//Has biomatter, sadly nanites are not able to use that
-						/obj/item/gun_upgrade/barrel,
-						/obj/item/gun_upgrade/muzzle,
-						/obj/item/gun_upgrade/mechanism,
-						/obj/item/gun_upgrade/trigger,
-						/obj/item/gun_upgrade/magwell,
-						/obj/item/gun_upgrade/scope,
-						/obj/item/gun_upgrade/underbarrel,
-						/obj/item/gun_upgrade/barrel/forged,
-						/obj/item/gun_upgrade/barrel/bore,
-						/obj/item/gun_upgrade/barrel/excruciator,	//Sadly has biomatter
-						/obj/item/gun_upgrade/mechanism/upgrade_kit,
-						/obj/item/gun_upgrade/mechanism/clock_block,//Brass and unknown tech
-						/obj/item/gun_upgrade/trigger/boom,			//Illegal
-						/obj/item/gun_upgrade/scope/watchman,
-						/obj/item/gun_upgrade/mechanism/glass_widow,
-						/obj/item/gun_upgrade/mechanism/greyson_master_catalyst,
-						/obj/item/gun_upgrade/mechanism/brass_kit,
-						/obj/item/gun_upgrade/trigger/honker,
-						/obj/item/gun_upgrade/mechanism/bikehorn,
-						/obj/item/gun_upgrade/mechanism/faulty_trapped,
-						/obj/item/gun_upgrade/trigger/faulty,
-						/obj/item/gun_upgrade/barrel/faulty,
-						/obj/item/gun_upgrade/muzzle/faulty,
-						/obj/item/gun_upgrade/mechanism/faulty,
-						/obj/item/gun_upgrade/scope/faulty
-	)
-
-	var/list/choice_mods = list()
-	// add new paths into the format of + subtypesof(XXX)
-	var/list/types = subtypesof(/obj/item/tool_upgrade) + subtypesof(/obj/item/gun_upgrade)
-	for (var/mod in types)
-		if (mod in blacklisted_types)
-			continue
-		var/obj/O = mod
-		choice_mods[initial(O.name)] = mod
-
-	var/obj/item/choice = input(src, "Which modification do you want?", "Mod Choice", null) as null|anything in choice_mods
-
-	if(choice && organ.pay_power_cost(1))
-		to_chat(src, "You permanently assign some of your nanites to create a modification.")
-		choice = choice_mods[choice]
-		put_in_hands(new choice(get_turf(src)))
 
 // Give the user a perk that allow them to create an ammo box every 30 minutes
 /mob/living/carbon/human/proc/nanite_ammo()

--- a/code/modules/nanogate/powers/user.dm
+++ b/code/modules/nanogate/powers/user.dm
@@ -52,7 +52,7 @@ List of powers in this page :
 			to_chat(src, "You permanently assign some of your nanites to enhancing your physical movement.")
 			stats.addPerk(PERK_NANITE_MUSCLE)
 			var/datum/perk/nanite_power/nanite_muscle/NM = stats.getPerk(PERK_NANITE_MUSCLE)
-			NM.regen_rate = variable_cost * 0.1
+			NM.speedup = variable_cost * 0.06
 			organ.organ_remove_verb(/mob/living/carbon/human/proc/nanite_muscle)
 	else
 		to_chat(src, "Assigning more nanites to enhance your muscles wouldn't offer any benefit.")

--- a/code/modules/nanogate/powers/user.dm
+++ b/code/modules/nanogate/powers/user.dm
@@ -36,7 +36,7 @@ List of powers in this page :
 // Give the user a perk that make him move faster
 /mob/living/carbon/human/proc/nanite_muscle()
 	set category = "Nanogate Powers"
-	set name = "Nanite Augment - Nanofiber Muscles" //0.06speedup per nanite point
+	set name = "Nanofiber Muscles" //0.06speedup per nanite point
 	set desc = "Spend a variable amount of your nanites to create nanite muscle to allow you to move faster."
 
 	var/obj/item/organ/internal/nanogate/organ = first_organ_by_type(/obj/item/organ/internal/nanogate)
@@ -60,7 +60,7 @@ List of powers in this page :
 // Give the user a perk that reduce incoming damage
 /mob/living/carbon/human/proc/nanite_armor()
 	set category = "Nanogate Powers"
-	set name = "Nanite Augment - Nanite Skin-Weave"
+	set name = "Nanite Skin-Weave"
 	set desc = "Spend a variable amount of your nanites to create subdermal nanite weave to protect your body."
 
 	var/obj/item/organ/internal/nanogate/organ = first_organ_by_type(/obj/item/organ/internal/nanogate)
@@ -85,7 +85,7 @@ List of powers in this page :
 // Allow the user to inject themselves with a chosen nanite.
 /mob/living/carbon/human/proc/nanite_chem()
 	set category = "Nanogate Powers"
-	set name = "Nanite Augment - Nanite Refabrication"
+	set name = "Nanite Refabrication"
 	set desc = "Convert some of your nanites into more specialized nanites, which slowly accumulate over time. Only works for organics."
 
 	var/obj/item/organ/internal/nanogate/organ = first_organ_by_type(/obj/item/organ/internal/nanogate)
@@ -119,7 +119,7 @@ List of powers in this page :
 // Give the user a tool or gun mod
 /mob/living/carbon/human/proc/nanite_mod()
 	set category = "Nanogate Powers"
-	set name = "Nanite Augment - Modification Fabricator"
+	set name = "Modification Fabricator"
 	set desc = "Spend some of your nanites to create a modification fabricator, which can construct tool and gun mods over a long period of time."
 
 	var/obj/item/organ/internal/nanogate/organ = first_organ_by_type(/obj/item/organ/internal/nanogate)
@@ -132,7 +132,7 @@ List of powers in this page :
 			to_chat(src, "Invalid nanite amount!")
 			return
 		if(organ.pay_power_cost(variable_cost))
-			to_chat(src, "You permanently assign some of your nanites to create ammunition boxes.")
+			to_chat(src, "You permanently assign some of your nanites to create tool and gun mods.")
 			stats.addPerk(PERK_NANITE_MODS)
 			var/datum/perk/nanite_power/nanite_mods/NA = stats.getPerk(PERK_NANITE_MODS)
 			if(variable_cost > 2)
@@ -144,7 +144,7 @@ List of powers in this page :
 // Give the user a perk that allow them to create an ammo box every 30 minutes
 /mob/living/carbon/human/proc/nanite_ammo()
 	set category = "Nanogate Powers"
-	set name = "Nanite Augment - Munition Fabrication"
+	set name = "Munition Fabrication"
 	set desc = "Spend some of your nanites to create an ammunition forge. More nanite assignment means faster recharge time."
 
 	var/obj/item/organ/internal/nanogate/organ = first_organ_by_type(/obj/item/organ/internal/nanogate)
@@ -190,7 +190,7 @@ List of powers in this page :
 // Spends points for increased food storage
 /mob/living/carbon/human/proc/nanite_food_storage()
 	set category = "Nanogate Powers"
-	set name = "Nanite Augment - Food Banking (1)"
+	set name = "Nanite Augment - Foodbanking (1)"
 	set desc = "Spend some of your nanites to allow the storage of additional nutrition on your body."
 
 	var/obj/item/organ/internal/nanogate/organ = first_organ_by_type(/obj/item/organ/internal/nanogate)

--- a/code/modules/nanogate/powers/user.dm
+++ b/code/modules/nanogate/powers/user.dm
@@ -117,7 +117,6 @@ List of powers in this page :
 		organ.organ_remove_verb(/mob/living/carbon/human/proc/nanite_chem)
 
 // Give the user a tool or gun mod
-//TODO:finish
 /mob/living/carbon/human/proc/nanite_mod()
 	set category = "Nanogate Powers"
 	set name = "Nanite Augment - Modification Fabricator"
@@ -126,6 +125,20 @@ List of powers in this page :
 	var/obj/item/organ/internal/nanogate/organ = first_organ_by_type(/obj/item/organ/internal/nanogate)
 	if(!organ)
 		return
+
+	if(!stats.getPerk(PERK_NANITE_MODS)) // Do they already have the perk?
+		var/variable_cost = input("How many points would you like to spend on a modification nanoforge? (60 minutes cooldown, decreased by 10 for every point above 2, cap of 3)", "Assign nanites") as null|num
+		if((variable_cost > 3) || (variable_cost < 2))
+			to_chat(src, "Invalid nanite amount!")
+			return
+		if(organ.pay_power_cost(variable_cost))
+			to_chat(src, "You permanently assign some of your nanites to create ammunition boxes.")
+			stats.addPerk(PERK_NANITE_MODS)
+			var/datum/perk/nanite_power/nanite_mods/NA = stats.getPerk(PERK_NANITE_MODS)
+			if(variable_cost > 2)
+				NA.cooldown = NA.cooldown - 10 MINUTES
+			organ.organ_remove_verb(/mob/living/carbon/human/proc/nanite_mod)
+
 
 
 // Give the user a perk that allow them to create an ammo box every 30 minutes

--- a/code/modules/nanogate/powers/user.dm
+++ b/code/modules/nanogate/powers/user.dm
@@ -135,7 +135,7 @@ List of powers in this page :
 			to_chat(src, "You permanently assign some of your nanites to create tool and gun mods.")
 			stats.addPerk(PERK_NANITE_MODS)
 			var/datum/perk/nanite_power/nanite_mods/NA = stats.getPerk(PERK_NANITE_MODS)
-			if(variable_cost > 2)
+			if(variable_cost == 3)
 				NA.cooldown = NA.cooldown - 10 MINUTES
 			organ.organ_remove_verb(/mob/living/carbon/human/proc/nanite_mod)
 

--- a/code/modules/nanogate/powers/user.dm
+++ b/code/modules/nanogate/powers/user.dm
@@ -60,7 +60,7 @@ List of powers in this page :
 // Give the user a perk that reduce incoming damage
 /mob/living/carbon/human/proc/nanite_armor()
 	set category = "Nanogate Powers"
-	set name = "Nanite Augment - Nanite Skin-Weave (3)"
+	set name = "Nanite Augment - Nanite Skin-Weave"
 	set desc = "Spend a variable amount of your nanites to create subdermal nanite weave to protect your body."
 
 	var/obj/item/organ/internal/nanogate/organ = first_organ_by_type(/obj/item/organ/internal/nanogate)
@@ -68,9 +68,16 @@ List of powers in this page :
 		return
 
 	if(!stats.getPerk(PERK_NANITE_ARMOR)) // Do they already have the perk?
-		if(organ.pay_power_cost(3))
+		var/variable_cost = input("How many points would you like to spend on subdermal nanoweave? (10 maximum health per point, max of 5)", "Assign nanites") as null|num
+		if((variable_cost > 5) || (variable_cost < 1))
+			to_chat(src, "Invalid nanite amount!")
+			return
+		if(organ.pay_power_cost(variable_cost))
 			to_chat(src, "You permanently assign some of your nanites to act as a reactive nano-weave armor, allowing you to resist physical brute damage.")
 			stats.addPerk(PERK_NANITE_ARMOR)
+			var/datum/perk/nanite_power/nanite_armor/NA = stats.getPerk(PERK_NANITE_ARMOR)
+			NA.max_health_adjust = variable_cost * 10
+			NA.adjustMaxHP()
 			organ.organ_remove_verb(/mob/living/carbon/human/proc/nanite_armor)
 	else
 		to_chat(src, "Your nanites are already providing as much armor as they can.")
@@ -78,8 +85,8 @@ List of powers in this page :
 // Allow the user to inject themselves with a chosen nanite.
 /mob/living/carbon/human/proc/nanite_chem()
 	set category = "Nanogate Powers"
-	set name = "Nanite Augment - Nanite Refabrication (1)"
-	set desc = "Convert some of your nanites into more specialized nanites. Only works for biological entities."
+	set name = "Nanite Augment - Nanite Refabrication"
+	set desc = "Convert some of your nanites into more specialized nanites, which slowly accumulate over time. Only works for organics."
 
 	var/obj/item/organ/internal/nanogate/organ = first_organ_by_type(/obj/item/organ/internal/nanogate)
 	if(!organ)
@@ -100,17 +107,21 @@ List of powers in this page :
 									"Nantidotes" = PERK_NANITE_CHEM_NANTIDOTE)
 
 	var/datum/perk/nanite_power/nanite_chem/choice = choices_perk[input(src, "Which nanite chem do you want?", "Chem Choice", null) as null|anything in choices_perk]
+	var/variable_cost = input("How many points would you like to spend on nanochem generation? (15 minutes cooldown, decreased by 5 for every point above 1, cap of 3)", "Assign nanites") as null|num
 
-	if(choice && organ.pay_power_cost(1)) // Check if the user actually made a choice, and if they did, check if they have the points.
+	if(choice && organ.pay_power_cost(variable_cost)) // Check if the user actually made a choice, and if they did, check if they have the points.
 		stats.addPerk(choice)
+		var/datum/perk/nanite_power/nanite_chem/NC = stats.getPerk(choice)
+		NC.cooldown_time = NC.cooldown_time / variable_cost
 		to_chat(src, "You permanently convert some of your nanites into specialized variants.")
 		organ.organ_remove_verb(/mob/living/carbon/human/proc/nanite_chem)
 
 // Give the user a tool or gun mod
+//TODO:finish
 /mob/living/carbon/human/proc/nanite_mod()
 	set category = "Nanogate Powers"
-	set name = "Nanite Augment - Modification Fabrication (1)"
-	set desc = "Spend some of your nanites to create a tool or gun mod."
+	set name = "Nanite Augment - Modification Fabricator"
+	set desc = "Spend some of your nanites to create a modification fabricator, which can construct tool and gun mods over a long period of time."
 
 	var/obj/item/organ/internal/nanogate/organ = first_organ_by_type(/obj/item/organ/internal/nanogate)
 	if(!organ)
@@ -131,11 +142,6 @@ List of powers in this page :
 						/obj/item/tool_upgrade/augment/crusader_seal,
 						/obj/item/tool_upgrade/artwork_tool_mod,
 						/obj/item/tool_upgrade/augment/sanctifier,	//Has biomatter, sadly nanites are not able to use that
-						/obj/item/tool_upgrade/armor/melee,
-						/obj/item/tool_upgrade/armor/bullet,
-						/obj/item/tool_upgrade/armor/energy,
-						/obj/item/tool_upgrade/armor/bomb,
-						/obj/item/tool_upgrade/productivity/waxcoat, //Biomatter
 						/obj/item/gun_upgrade/barrel,
 						/obj/item/gun_upgrade/muzzle,
 						/obj/item/gun_upgrade/mechanism,
@@ -159,7 +165,6 @@ List of powers in this page :
 						/obj/item/gun_upgrade/trigger/faulty,
 						/obj/item/gun_upgrade/barrel/faulty,
 						/obj/item/gun_upgrade/muzzle/faulty,
-						/obj/item/gun_upgrade/muzzle/pain_maker,
 						/obj/item/gun_upgrade/mechanism/faulty,
 						/obj/item/gun_upgrade/scope/faulty
 	)
@@ -183,23 +188,29 @@ List of powers in this page :
 // Give the user a perk that allow them to create an ammo box every 30 minutes
 /mob/living/carbon/human/proc/nanite_ammo()
 	set category = "Nanogate Powers"
-	set name = "Nanite Augment - Munition Fabrication (1)"
-	set desc = "Spend some of your nanites to create an ammo."
+	set name = "Nanite Augment - Munition Fabrication"
+	set desc = "Spend some of your nanites to create an ammunition forge. More nanite assignment means faster recharge time."
 
 	var/obj/item/organ/internal/nanogate/organ = first_organ_by_type(/obj/item/organ/internal/nanogate)
 	if(!organ)
 		return
 
 	if(!stats.getPerk(PERK_NANITE_AMMO)) // Do they already have the perk?
-		if(organ.pay_power_cost(1))
+		var/variable_cost = input("How many points would you like to spend on an ammunition nanoforge? (15 minutes cooldown, decreased by 5 for every point above 1, cap of 3)", "Assign nanites") as null|num
+		if((variable_cost > 3) || (variable_cost < 1))
+			to_chat(src, "Invalid nanite amount!")
+			return
+		if(organ.pay_power_cost(variable_cost))
 			to_chat(src, "You permanently assign some of your nanites to create ammunition boxes.")
 			stats.addPerk(PERK_NANITE_AMMO)
+			var/datum/perk/nanite_power/nanite_ammo/NA = stats.getPerk(PERK_NANITE_AMMO)
+			NA.cooldown = NA.cooldown/variable_cost
 			organ.organ_remove_verb(/mob/living/carbon/human/proc/nanite_ammo)
 
 // Spends points for stats
 /mob/living/carbon/human/proc/nanite_stats()
 	set category = "Nanogate Powers"
-	set name = "Nanite Augment - Mindbanking (2)"
+	set name = "Nanite Augment - Mindbanking"
 	set desc = "Spend some of your nanites to increase your knowledge."
 
 	var/obj/item/organ/internal/nanogate/organ = first_organ_by_type(/obj/item/organ/internal/nanogate)
@@ -214,11 +225,11 @@ List of powers in this page :
 									"Vigilance" = STAT_VIG
 									)
 
-	var/stat = choices_stats[input(src, "Which nanite chem do you want?", "Stats Choice", null) as null|anything in choices_stats]
-
-	if(stat && organ.pay_power_cost(2))
+	var/stat = choices_stats[input(src, "Which aspect of your knowledge would you like to enhance??", "Stats Choice", null) as null|anything in choices_stats]
+	var/variable_cost = input("How many points would you like to spend on [stat]? (10 per point)", "Assign nanites") as null|num
+	if(stat && organ.pay_power_cost(variable_cost))
 		to_chat(src, "You permanently assign some of your nanites to be databanks.")
-		stats.changeStat(stat, 5)
+		stats.changeStat(stat, (variable_cost * 10))
 
 // Spends points for increased food storage
 /mob/living/carbon/human/proc/nanite_food_storage()
@@ -242,7 +253,7 @@ List of powers in this page :
 // Allows you to drink metals for food
 /mob/living/carbon/human/proc/nanite_metal_drinker()
 	set category = "Nanogate Powers"
-	set name = "Nanite Augment - Metal-Eater (2)"
+	set name = "Nanite Augment - Metal-Eater (1)"
 	set desc = "Spend some of your nanites to allow you to drink basic metals for nutrition. Does not nullifies any harmful effects of drinking said metal."
 
 	var/obj/item/organ/internal/nanogate/organ = first_organ_by_type(/obj/item/organ/internal/nanogate)
@@ -255,7 +266,7 @@ List of powers in this page :
 		return
 
 	if(!stats.getPerk(PERK_NANITE_METAL_EATER)) // Do they already have the perk?
-		if(organ.pay_power_cost(2))
+		if(organ.pay_power_cost(1))
 			to_chat(src, "You permanently assign some of your nanites to break down metals in your guts for nutrition.")
 			stats.addPerk(PERK_NANITE_METAL_EATER)
 			organ.organ_remove_verb(/mob/living/carbon/human/proc/nanite_metal_drinker)

--- a/code/modules/projectiles/guns/mods/mods.dm
+++ b/code/modules/projectiles/guns/mods/mods.dm
@@ -716,7 +716,7 @@
 
 /obj/item/gun_upgrade/scope/killer
 	name = "Void Wolf \"Contract Killer\" scope"
-	desc = "A digital scope machine printed by void wolf reavers, often combined with gauss weaponry and thermal scanners to cause breaches to ships and dead pilots in void-based dog fights."
+	desc = "A digital scope machine-printed by void wolf reavers, often combined with gauss weaponry and thermal scanners to cause breaches to ships and dead pilots in void-based dog fights."
 	icon_state = "Killer"
 	price_tag = 60
 


### PR DESCRIPTION
wow, nanogates are so cool! but the perk system is pretty inflexible. what if people could choose the point assignment for certain numerical perks in order to fit their needs better?
	
nanogate regen has been buffed slightly, as spending 7 points (the previous default) now grants 0.7/tick regen instead of 0.5.

nanite chem is no longer one-time use, and regenerates in 15min. with extra point investiture this goes down to 5 minutes with 3 points (max)

nanite ammo now  regenerates in 15min. with extra point investiture this goes down to 5 minutes with 3 points (max)

nanite munition fabricator is now reusable every hour, but now costs 2 points by default. another point can be spent to reduce cooldown by 10 minutes.

mindbanking is now 10 points/1 nanogate point.

nanite bot is... imo fine as it is, with manual control? mob AI needs changing but that's out of scope
nanite rig also is decent enough, no issues with it

## Changelog
:cl:
balance:  nanogate users can now choose how many points to spend on their numerical perks (currently only speedup and regen)
/:cl:


