### PR TITLE
Character Editor now correctly loads characters and does not spam adminlogs

### DIFF
--- a/code/modules/client/preference_setup/general/06_furry.dm
+++ b/code/modules/client/preference_setup/general/06_furry.dm
@@ -170,7 +170,6 @@ datum/preferences
 			var/new_marking = input(user, "Choose a marking to add:", CHARACTER_PREFERENCE_INPUT_TITLE, null) as null|anything in GLOB.body_marking_list - pref.body_markings
 			if(new_marking && CanUseTopic(user))
 				pref.body_markings[new_marking] = "#000000"
-				log_and_message_admins("[key_name(usr)] has picked a new marking.") // So that admins can see who's crashing the server through sparkledogs.
 			return TOPIC_REFRESH_UPDATE_PREVIEW
 	if(href_list["marking"])
 		if(CanUseTopic(user))

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -22,18 +22,15 @@
 	loaded_preferences = S
 	return 1
 
-/datum/preferences/proc/save_preferences(var/announce = 1)
+/datum/preferences/proc/save_preferences()
 	if(!path)				return 0
 	if(!check_cooldown())
 		if(istype(client))
 			to_chat(client, SPAN_WARNING("You're attempting to save your preferences a little too fast. Wait half a second, then try again."))
-			log_and_message_admins("[key_name(usr)] has saved their preferences really fast and was stopped.")
 		return 0
 	var/savefile/S = new /savefile(path)
 	if(!S)					return 0
 	S.cd = "/"
-	if(announce)
-		log_and_message_admins("[key_name(usr)] has saved their preferences.")
 
 	S["version"] << SAVEFILE_VERSION_MAX
 	player_setup.save_preferences(S)
@@ -45,7 +42,6 @@
 	if(!check_cooldown())
 		if(istype(client))
 			to_chat(client, SPAN_WARNING("You're attempting to load your character a little too fast. Wait half a second, then try again."))
-			log_and_message_admins("[key_name(usr)] has loaded a character too fast and was stopped.")
 		return 0
 
 	if(!fexists(path))		return 0
@@ -71,7 +67,7 @@
 		S.cd = GLOB.maps_data.character_load_path(S, default_slot)
 
 	loaded_character = S
-	log_and_message_admins("[key_name(usr)] has loaded a character.")
+	categoriesChanged = "All"	//Forces the character editor to refresh everything, preventing characters from getting their body markings (visually) mixed up
 
 	return 1
 
@@ -80,7 +76,6 @@
 	if(!check_cooldown())
 		if(istype(client))
 			to_chat(client, SPAN_WARNING("You're attempting to save your character a little too fast. Wait half a second, then try again."))
-			log_and_message_admins("[key_name(usr)] has saved a character really fast and was stopped.")
 		return 0
 	var/savefile/S = new /savefile(path)
 	if(!S)					return 0
@@ -89,7 +84,6 @@
 	S["version"] << SAVEFILE_VERSION_MAX
 	player_setup.save_character(S)
 	loaded_character = S
-	log_and_message_admins("[key_name(usr)] has saved a character.")
 	return S
 
 /datum/preferences/proc/sanitize_preferences()


### PR DESCRIPTION
## About The Pull Request
This PR simply removes paranoid adminlogs from the character creator and also makes it such that loading characters properly refreshes the preview instead of exploding bodymarkings together.

## Changelog
:cl: Toriate
fix: Character creator should now load characters properly. Also removed adminlog spam.
/:cl: