### PR TITLE
Vote to power the colony, take two.

### DIFF
--- a/code/controllers/subsystems/voting/poll_types.dm
+++ b/code/controllers/subsystems/voting/poll_types.dm
@@ -317,6 +317,30 @@
 	text = "We have enough chaos already!"
 
 
+/datum/poll/power
+	name = "Power the Colony"	// Equinox edit: simple edit to keep the lights on during engineerless lowpop rounds.
+	question = "No engineers? Have no fear! Simply vote here and all your problems will go away (not really)."
+	time = 60
+	choice_types = list(/datum/vote_choice/power, /datum/vote_choice/nopower)
+	minimum_voters = 0
+	only_admin = FALSE
+
+	multiple_votes = FALSE
+	can_revote = TRUE
+	can_unvote = TRUE
+	cooldown = 30 MINUTES
+	next_vote = 5 MINUTES	//Have to wait 5 minutes after roundstart before doing it
+	see_votes = TRUE
+
+/datum/vote_choice/power
+	text = "Power to the people!"
+
+/datum/vote_choice/power/on_win()
+	power_restore()
+
+/datum/vote_choice/nopower
+	text = "Don't ruin my immersion."
+
 
 /datum/poll/custom
 	name = "Custom"


### PR DESCRIPTION
## About The Pull Request
Adds a simple vote whether or not to power the station. Useful for lowpop rounds with no engineers to keep the lights on. Basically just ported forward from Occulus minus the shields, since the colony doesn't have any. On passing, the vote triggers the same proc as an admin hitting the 'power all SMES' thing.

Useful for when we want to perform Shakespeare in the Park instead of Shakespeare in the Dark.

## Changelog
:cl:
code: new vote type to fully power the colony
/:cl:
