### PR TITLE
Adding more alt styles to the Vector (acolyte)'s armor

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -604,6 +604,17 @@
 	options["lemniscate helmet"] = "lemniscate_helmet"
 	options["divisor helmet"] = "divisor_helmet"
 	options["monomial helmet"] = "monomial_helmet"
+	options["divisor plate greathelm"] = "divisor_plate_greathelm"
+	options["divisor guard helmet"] = "divisor_guardsmen_helmet"
+	options["tessellate veil"] = "tessellate_veil"
+	options["tessellate maskheadgear"] = "tessellate_maskheadgear"
+	options["factorial powerhood"] = "factorial_powerhood"
+	options["factorial vessel shlemofon"] = "factorial_vesselcrew_shlemofon"
+	options["divisor plate greathelm_alt"] = "divisor_plate_greathelm_alt"
+	options["divisor guardsmen helmet snout"] = "divisor_guardsmen_helmet_alt"
+	options["tessellate veil snout"] = "tessellate_veil_alt"
+	options["tessellate maskheadgear snout"] = "tessellate_maskheadgear_alt"
+	options["factorial powerhood snout"] = "factorial_powerhood_alt"
 
 	var/choice = input(M,"What kind of style do you want?","Adjust Style") as null|anything in options
 

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -331,6 +331,16 @@
 	options["vinculum dress garbs"] = "vinculum_cassock"
 	options["tessellate plague garbs"] = "tessellate_plague_garbs"
 	options["tessellate dark plague garbs"] = "tessellate_plague_garbs_dark"
+	options["divisor plate armor"] = "divisor_plate_armor"
+	options["tangent guard armor"] = "divisor_guardsmen_armor"
+	options["tessellate riding habit"] = "tessellate_riding_habit"
+	options["tessellate doctor garbs"] = "tessellate_doctor_garbs"
+	options["lemniscate garbs"] = "lemniscate_garbs"
+	options["lemniscate caftan"] = "lemniscate_caftan"
+	options["monomial kasaya"] = "monomial_kasaya"
+	options["monomial gusoku"] = "monomial_gusoku"
+	options["factorial powergarb"] = "factorial_powergarb"
+	options["factorial vessel armor"] = "factorial_vesselcrew_armor"
 
 	var/choice = input(M,"What kind of style do you want?","Adjust Style") as null|anything in options
 


### PR DESCRIPTION

## About The Pull Request
Compensates for #49 deleting the printable armor bundle. Also introduces previously unused furry snout friendly helmet options.

![dreamseeker_4SkuUt2ZJT](https://github.com/user-attachments/assets/49740ff6-e081-4520-af6b-b97d50c4ab83)
![dreamseeker_AxdweJn5eD](https://github.com/user-attachments/assets/d89df2ca-5ba2-4b21-a6d0-9aa25dd183da) ![dreamseeker_cKO2OUpms3](https://github.com/user-attachments/assets/ee5e5060-9570-4bdb-9cdb-9295e619dfde)


## Changelog
:cl: Toriate
add: Vector armor now has new alt style options. Vector helmet also has new snout options.
/:cl: