### PR TITLE
Altyn helmet fix

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -1659,8 +1659,8 @@
 	name = "altyn helmet"
 	desc = "A titanium helmet of serbian origin. Still widely used despite being discontinued."
 	icon_state = "altyn"
-	armor_up = list(melee = 2, bullet = 3, energy = 2, bomb = 15, bio = 0, rad = 0)
-	armor_list = list(melee = 5, bullet = 4, energy = 0, bomb = 35, bio = 0, rad = 0)
+	armor_up = list(melee = 2, bullet = 3, energy = 0, bomb = 15, bio = 0, rad = 0)
+	armor_list = list(melee = 5, bullet = 4, energy = 2, bomb = 35, bio = 0, rad = 0)
 	siemens_coefficient = 1
 	up = TRUE
 

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -1659,8 +1659,8 @@
 	name = "altyn helmet"
 	desc = "A titanium helmet of serbian origin. Still widely used despite being discontinued."
 	icon_state = "altyn"
-	armor_up = list(melee = 5, bullet = 4, energy = 0, bomb = 15, bio = 0, rad = 0)
-	armor_list = list(melee = 2, bullet = 3, energy = 2, bomb = 35, bio = 0, rad = 0)
+	armor_up = list(melee = 2, bullet = 3, energy = 2, bomb = 15, bio = 0, rad = 0)
+	armor_list = list(melee = 5, bullet = 4, energy = 0, bomb = 35, bio = 0, rad = 0)
 	siemens_coefficient = 1
 	up = TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

A very simple fix that only occurs for the Altyn helmet. Generally, there are 4 types of helmet (with variations) that has an option to "flip up" the face mask. 

For all of them, the armor value consistently go down when the facemask is up, and go up when the face mask is down to protect you _EXCEPT_ the Altyn and it's variations such as Maska.
* This fixes that problem, since `armor_up` is the alternative value called when the face plate is pushed up and out of the way to show the person their face.
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
## Changelog
:cl:
fix: fixes the altyn helmet armor value
/:cl:
