### PR TITLE
Revert "mobs now respect armor when attacking"

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -413,15 +413,10 @@
 
 	if(!damage || !istype(user))
 		return
-	
-	var/used_divisor = 1
-	if(isliving(user))
-		var/mob/living/L = user
-		used_divisor = L.armor_divisor
-	var/attack_BP = BP_CHEST
-	if(prob(20))
-		attack_BP = pick(list(BP_L_LEG, BP_R_LEG, BP_R_ARM, BP_L_ARM, BP_GROIN, BP_HEAD))
-	damage_through_armor(damage, damagetype, attack_BP, ARMOR_MELEE, used_divisor, sharp=sharp, edge=edge)
+	if(damagetype == BRUTE)
+		adjustBruteLoss(damage)
+	else
+		adjustFireLoss(damage)
 	user.attack_log += text("\[[time_stamp()]\] <font color='red'>attacked [src.name] ([src.ckey])</font>")
 	src.attack_log += text("\[[time_stamp()]\] <font color='orange'>was attacked by [user.name] ([user.ckey])</font>")
 	src.visible_message(SPAN_DANGER("[user] has [attack_message] [src]!"))


### PR DESCRIPTION
Reverts Equinox-SS13/equinox-sojourn#40

Turns out that we have been looking at the wrong spot in the code. The change applies to the wrong type of mobs since human mobs have their own damage-handling process at:

https://github.com/Equinox-SS13/equinox-sojourn/blob/5e666c7e221e980e4edf57801bd691e52df4a638/code/modules/mob/living/carbon/human/human_attackhand.dm#L311

So far it has been a travesty. We had been too confident in the change. This revert means we should go look at other options of the armour issue instead. Look at other problems that more worth investigating.

## Changelog
:cl:
fix: Reverted a change to how simple mobs are damaged.
/:cl:
