### PR TITLE
Sanity exploit fixing

### DIFF
--- a/code/datums/objective/individual_objective/individual_objective.dm
+++ b/code/datums/objective/individual_objective/individual_objective.dm
@@ -65,7 +65,7 @@
 	update_faction_score()
 	to_chat(owner,  SPAN_NOTICE("You have completed the personal objective: [name]"))
 	H.sanity.give_insight(insight_reward)
-	H.sanity.finish_rest()
+	//H.sanity.finish_rest()	//Uncommenting this line causes anyone to gain a level one minute after they finish the personal objective. Please. Please do not release this.
 
 /datum/individual_objective/proc/get_description()
 	var/n_desc = desc

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -225,6 +225,20 @@
 								to_chat(user, "<span class='[pain > 50 ? "danger" : "warning"]'>Your amateur actions caused you [pain > 50 ? "a lot of " : ""]pain.</span>")
 				else
 					to_chat(target, SPAN_NOTICE("You feel a tiny prick!"))
+			if(istype(target, /obj/item/reagent_containers/food/snacks))
+				var/cheesecheck = FALSE
+				var/blamereagent
+				var/list/blacklistedreagents = list("water", "nutriment")
+				for(var/datum/reagent/R in src.reagents.reagent_list)
+					if(R.id in blacklistedreagents)
+						cheesecheck = TRUE
+						blamereagent = R.id
+						continue
+				if(cheesecheck)
+					to_chat(user, "Adding [blamereagent] to [target] seems like it would ruin it.")
+					return
+				else
+					trans = reagents.trans_to(target, amount_per_transfer_from_this)
 			else
 				trans = reagents.trans_to(target, amount_per_transfer_from_this)
 			to_chat(user, SPAN_NOTICE("You inject [trans] units of the solution. [src] now contains [src.reagents.total_volume] units."))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Prevents players from injecting water and nutriment into food items with syringes. This behaviour was involved in an infinite sanity/insight exploit that allowed massive powerleveling. Players who attempt to inject water or nutriment into food items will be met with a line of text reading "Adding [reagent] to [the food] seems like it would ruin it." and no reagents from the syringe will be added. Other reagents, including poisons, toxins, tar, and medicines, can be added. This will make the exploit a LOT harder or remove it entirely. 

Additionally, fixed Individual Objectives providing a level up one minute after completing objectives, allowing for massive powerleveling. Objectives will now reward around 25 insight only. 
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
<!-- fixed: Powerleveling bugs. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
