### PR TITLE
Hopefully fixes (some) qdel runtimes at roundstart

### DIFF
--- a/code/controllers/subsystems/migration.dm
+++ b/code/controllers/subsystems/migration.dm
@@ -64,6 +64,10 @@ This proc will attempt to create a burrow against a wall, within view of the tar
 		if (F.is_wall)
 			continue
 
+		//No deleting pipes just to spawn a burrow in
+		if(!turf_clear(F))
+			continue
+
 		//No stacking multiple burrows per tile
 		if (locate(/obj/structure/burrow) in F)
 			continue


### PR DESCRIPTION
## About The Pull Request
When burrows spawn on top of pipes, they get deleted for reasons unknown. When a pipe is deleted this way, it causes a runtime. This should prevent burrows from spawning on top of pipes and thus also prevents those runtimes, in theory.

## Changelog
:cl: Toriate
fix: hypothetically fixes burrows deleting pipes causing weird runtimes.
/:cl: