### PR TITLE
Increase in Mob Performance

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -459,7 +459,10 @@
 	if(!can_open(forced))
 		return
 	operating = TRUE
-	activate_mobs_in_range(src, 10)
+	for(var/mob/living/G in GLOB.player_list)
+		if(G.mind.current)
+			activate_mobs_in_range(src, 15)    // Perhaps a solution to the lag. Players now activate mobs via doors.
+			// to_chat(world, "\ [G.name] successfully activated mob AI with a door.") // Debug line to make sure mobs aren't activating.
 
 	set_opacity(0)
 	if(istype(src, /obj/machinery/door/airlock/multi_tile/metal))

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -460,7 +460,7 @@
 		return
 	operating = TRUE
 	//This checks if whoever is using the door has a client to activate mobs.
-	if(usr.client)
+	if(usr.client && istype(usr, /mob/living/carbon/human))
 		activate_mobs_in_range(src, 15)
 
 	set_opacity(0)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -459,11 +459,9 @@
 	if(!can_open(forced))
 		return
 	operating = TRUE
-	var/mob/living/G
-	if(G in GLOB.player_list && G.mind.current)
-		activate_mobs_in_range(src, 15)    // Perhaps a solution to the lag. Players now activate mobs via doors.
-		// to_chat(world, "\ [G.name] successfully activated mob AI with a door.") // Debug line to make sure mobs aren't activating.
-
+	//if(user.mind.current)
+	//	activate_mobs_in_range(src, 15)
+	//	to_chat(world, " [user.name] has successfully activated the AI at [src]") // Debug Code
 	set_opacity(0)
 	if(istype(src, /obj/machinery/door/airlock/multi_tile/metal))
 		f5?.set_opacity(0)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -459,9 +459,10 @@
 	if(!can_open(forced))
 		return
 	operating = TRUE
+	//This checks if whoever is using the door has a client to activate mobs.
 	if(usr.client)
 		activate_mobs_in_range(src, 15)
-		to_chat(world, " [usr.name] has successfully activated the AI at [src]") // Debug Code
+
 	set_opacity(0)
 	if(istype(src, /obj/machinery/door/airlock/multi_tile/metal))
 		f5?.set_opacity(0)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -459,9 +459,9 @@
 	if(!can_open(forced))
 		return
 	operating = TRUE
-	//if(user.mind.current)
-	//	activate_mobs_in_range(src, 15)
-	//	to_chat(world, " [user.name] has successfully activated the AI at [src]") // Debug Code
+	if(usr.client)
+		activate_mobs_in_range(src, 15)
+		to_chat(world, " [usr.name] has successfully activated the AI at [src]") // Debug Code
 	set_opacity(0)
 	if(istype(src, /obj/machinery/door/airlock/multi_tile/metal))
 		f5?.set_opacity(0)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -459,10 +459,10 @@
 	if(!can_open(forced))
 		return
 	operating = TRUE
-	for(var/mob/living/G in GLOB.player_list)
-		if(G.mind.current)
-			activate_mobs_in_range(src, 15)    // Perhaps a solution to the lag. Players now activate mobs via doors.
-			// to_chat(world, "\ [G.name] successfully activated mob AI with a door.") // Debug line to make sure mobs aren't activating.
+	var/mob/living/G
+	if(G in GLOB.player_list && G.mind.current)
+		activate_mobs_in_range(src, 15)    // Perhaps a solution to the lag. Players now activate mobs via doors.
+		// to_chat(world, "\ [G.name] successfully activated mob AI with a door.") // Debug line to make sure mobs aren't activating.
 
 	set_opacity(0)
 	if(istype(src, /obj/machinery/door/airlock/multi_tile/metal))

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -66,7 +66,7 @@
 
 	SSmove_manager.stop_looping(src)
 
-	activate_mobs_in_range(src, 5) //Its quite clear to everyone close by when something dies
+	activate_mobs_in_range(src, 15) //Its quite clear to everyone close by when something dies.
 	facing_dir = null
 
 	if(!gibbed && deathmessage != "no message") // This is gross, but reliable. Only brains use it.

--- a/code/modules/mob/living/carbon/superior_animal/giant_spider/giant_spider.dm
+++ b/code/modules/mob/living/carbon/superior_animal/giant_spider/giant_spider.dm
@@ -44,7 +44,10 @@
 	melee_damage_lower = 12
 	melee_damage_upper = 17
 
-	min_breath_required_type = 3
+	breath_required_type = NONE
+	breath_poison_type = NONE
+	min_breath_required_type = 0 //Insects shouldn't be oxygen hogs.
+
 	min_air_pressure = 15 //below this, brute damage is dealt
 
 	fleshcolor = "#1E536E"

--- a/code/modules/mob/living/carbon/superior_animal/roach/roach.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/roach.dm
@@ -38,7 +38,10 @@
 	melee_damage_upper = 4
 	var/knockdown_odds = 1 //1% KO odds
 
-	min_breath_required_type = 3
+	breath_required_type = NONE
+	breath_poison_type = NONE
+	min_breath_required_type = 0 //Insects shouldn't be oxygen hogs.
+
 	min_air_pressure = 15 //below this, brute damage is dealt
 
 	faction = "roach"

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -11,9 +11,9 @@
 			else
 				if(check_surrounding_area(7))
 					activate_ai()
-					life_cycles_before_scan = 29 //So it doesn't fall asleep just to wake up the next tick
+					life_cycles_before_scan = 29 / rand(0.1, 1.25) //So it doesn't fall asleep just to wake up the next tick
 				else
-					life_cycles_before_scan = 240
+					life_cycles_before_scan = 240 / rand(0.75, 1.25) // Now has random ticks to not bottleneck the CPU and cause it to choke.
 
 			if(life_cycles_before_sleep)
 				life_cycles_before_sleep--

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -14,7 +14,7 @@
 	var/life_cycles_before_scan = 360
 
 	var/stasis = FALSE
-	var/AI_inactive = FALSE
+	var/AI_inactive = TRUE // Mobs should spawn with AI disabled by default, that way we don't have random mobs active for no reason. Why this wasn't the case is beyond me.
 
 	var/inventory_shown = 1
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -192,7 +192,7 @@
 
 
 /mob/proc/Life()
-	LEGACY_SEND_SIGNAL(src, COMSIG_MOB_LIFE)
+	SEND_SIGNAL(src, COMSIG_MOB_LIFE) // Unsure why it was using legacy. Now uses the updated SEND_SIGNAL.
 //	if(organStructure)
 //		organStructure.ProcessOrgans()
 	return

--- a/maps/_DeepForest/map/_Beast_Cave.dmm
+++ b/maps/_DeepForest/map/_Beast_Cave.dmm
@@ -85,7 +85,6 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest/beast_cave_dark)
 "aw" = (
-/obj/random/mob/croaker/low_chance,
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
 /mob/living/simple_animal/crab,
@@ -264,21 +263,12 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest/beast_cave_dark)
 "br" = (
-/obj/random/mob/croaker/low_chance,
 /obj/structure/invislightsmall,
 /obj/structure/invislight,
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
 /mob/living/simple_animal/crab,
 /turf/simulated/floor/beach/water/jungledeep,
-/area/nadezhda/outside/forest/beast_cave_dark)
-"bs" = (
-/obj/random/mob/croaker/low_chance,
-/obj/structure/invislightsmall,
-/obj/structure/invislight,
-/obj/effect/overlay/water,
-/obj/effect/overlay/water/top,
-/turf/simulated/floor/beach/water/shallow,
 /area/nadezhda/outside/forest/beast_cave_dark)
 "bt" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1134,9 +1124,10 @@
 /turf/simulated/floor/beach/sand,
 /area/nadezhda/outside/forest/beast_cave_light)
 "eX" = (
+/obj/structure/flora/small/grassa5,
 /obj/effect/decal/cleanable/dirt,
-/obj/random/mob/roaches/low_chance,
-/turf/simulated/floor/asteroid/dirt,
+/obj/random/mob/undergroundmob/low_chance,
+/turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/forest/beast_cave_dark)
 "eY" = (
 /obj/effect/overlay/water,
@@ -2146,12 +2137,9 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/forest/beast_cave_light)
 "iM" = (
-/obj/structure/flora/ausbushes/palebush,
-/mob/living/simple_animal/hostile/snake{
-	layer = 3.8;
-	name = "tree jumping viper"
-	},
-/turf/simulated/floor/asteroid/dirt/mud,
+/obj/structure/flora/ausbushes/reedbush,
+/obj/random/mob/croaker/low_chance,
+/turf/simulated/floor/beach/water/jungle,
 /area/nadezhda/outside/forest/beast_cave_light)
 "iN" = (
 /obj/structure/flora/ausbushes/reedbush,
@@ -2298,11 +2286,6 @@
 /obj/random/techpart/low_chance,
 /turf/simulated/floor/asteroid/dirt/mud,
 /area/nadezhda/outside/forest/beast_cave_light)
-"jp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/mob/roaches/low_chance,
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/forest/beast_cave_light)
 "jq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/beach/water/swamp,
@@ -2437,9 +2420,8 @@
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/forest/beast_cave_dark)
 "jP" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/mushroom,
-/turf/simulated/floor/asteroid/dirt/dark,
+/obj/random/mob/voidwolf/low_chance,
+/turf/simulated/floor/wood/wild5,
 /area/nadezhda/outside/forest/beast_cave_dark)
 "jQ" = (
 /obj/item/remains/tajaran,
@@ -2457,7 +2439,6 @@
 /turf/simulated/floor/beach/water/swamp,
 /area/nadezhda/outside/forest/beast_cave_light)
 "jT" = (
-/obj/random/mob/croaker/low_chance,
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
 /mob/living/simple_animal/crab,
@@ -2920,7 +2901,6 @@
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/rubble,
 /obj/random/cluster/spiders/low_chance,
-/obj/random/cluster/roaches/low_chance,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest/beast_cave_dark)
 "lD" = (
@@ -2957,14 +2937,6 @@
 /obj/machinery/reagentgrinder/portable,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/outside/forest/swamp_hut)
-"lJ" = (
-/obj/structure/flora/ausbushes/pointybush,
-/mob/living/simple_animal/hostile/snake{
-	layer = 3.8;
-	name = "tree jumping viper"
-	},
-/turf/simulated/floor/asteroid/dirt/mud,
-/area/nadezhda/outside/forest/beast_cave_light)
 "lK" = (
 /obj/structure/table/standard,
 /obj/item/reagent_containers/food/condiment/saltshaker{
@@ -3661,10 +3633,6 @@
 /area/nadezhda/outside/forest/beast_cave_dark)
 "og" = (
 /obj/structure/flora/small/trailrocka4,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest/beast_cave_dark)
-"oh" = (
-/obj/random/cluster/spiders/low_chance,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest/beast_cave_dark)
 "oi" = (
@@ -4444,10 +4412,9 @@
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/outside/forest/beast_cave_dark)
 "rd" = (
-/obj/effect/decal/cleanable/blood/drip,
-/obj/random/mob/render/low_chance,
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/forest/beast_cave_dark)
+/obj/structure/flora/small/bushb2,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/forest/beast_cave_light)
 "re" = (
 /obj/structure/flora/small/lavarock1,
 /obj/effect/decal/cleanable/blood/drip,
@@ -4510,11 +4477,6 @@
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/blood/drip,
 /turf/simulated/floor/rock,
-/area/nadezhda/outside/forest/beast_cave_dark)
-"rq" = (
-/obj/effect/decal/cleanable/blood/drip,
-/obj/random/mob/voidwolf/low_chance,
-/turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest/beast_cave_dark)
 "rr" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4657,9 +4619,7 @@
 /turf/unsimulated/mineral,
 /area/nadezhda/outside/forest/beast_cave_light)
 "rS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/snake,
+/obj/random/mob/undergroundmob,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest/beast_cave_dark)
 "rT" = (
@@ -4737,9 +4697,10 @@
 /turf/simulated/floor/rock,
 /area/nadezhda/outside/forest/beast_cave_dark)
 "sk" = (
-/mob/living/simple_animal/hostile/snake,
-/turf/simulated/floor/rock,
-/area/nadezhda/outside/forest/beast_cave_dark)
+/obj/structure/flora/big/bush2,
+/mob/living/simple_animal/chicken,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest/beast_cave_light)
 "sl" = (
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest/beast_cave_dark)
@@ -5204,11 +5165,6 @@
 /obj/map_data/beast_cave,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest/beast_cave_light)
-"tV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/mob/undergroundmob,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest/beast_cave_dark)
 "tW" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/asteroid/grass,
@@ -5670,10 +5626,8 @@
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/outside/forest/swamp_hut)
 "vx" = (
-/obj/random/mob/croaker/low_chance,
-/obj/effect/overlay/water/top,
-/obj/effect/overlay/water,
-/turf/simulated/floor/beach/water/jungledeep,
+/obj/random/mob/undergroundmob,
+/turf/simulated/floor/rock,
 /area/nadezhda/outside/forest/beast_cave_dark)
 "vz" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6229,14 +6183,6 @@
 /obj/structure/flora/small/trailrockb3,
 /turf/simulated/floor/rock/grey,
 /area/nadezhda/outside/forest/beast_cave_dark)
-"Cf" = (
-/obj/random/mob/croaker/low_chance,
-/obj/structure/invislightsmall,
-/obj/structure/invislight,
-/obj/effect/overlay/water,
-/obj/effect/overlay/water/top,
-/turf/simulated/floor/beach/water/jungledeep,
-/area/nadezhda/outside/forest/beast_cave_dark)
 "Cj" = (
 /obj/structure/flora/small/grassa5,
 /obj/effect/decal/cleanable/dirt,
@@ -6677,11 +6623,11 @@
 /turf/simulated/floor/beach/sand,
 /area/nadezhda/outside/forest/beast_cave_light)
 "Hj" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/ppflowers,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/rubble,
 /obj/random/mob/undergroundmob/low_chance,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest/beast_cave_light)
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/forest/beast_cave_dark)
 "Hk" = (
 /obj/effect/spider/stickyweb,
 /obj/effect/decal/cleanable/rubble,
@@ -6884,13 +6830,6 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/beach/sand,
 /area/nadezhda/outside/forest/beast_cave_dark)
-"JL" = (
-/mob/living/simple_animal/hostile/snake{
-	layer = 3.8;
-	name = "tree jumping viper"
-	},
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/forest/beast_cave_light)
 "JN" = (
 /obj/structure/flora/small/rock5,
 /obj/structure/invislightsmall,
@@ -7682,12 +7621,6 @@
 /obj/random/scrap/dense_weighted,
 /turf/simulated/floor/rock,
 /area/nadezhda/outside/forest/beast_cave_dark)
-"SH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/rubble,
-/mob/living/simple_animal/mushroom,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/outside/forest/beast_cave_dark)
 "SI" = (
 /obj/item/stack/rods/random,
 /obj/effect/decal/cleanable/blood/gibs/core,
@@ -7991,12 +7924,11 @@
 /turf/simulated/floor/rock,
 /area/nadezhda/outside/forest/beast_cave_light)
 "Wg" = (
-/mob/living/simple_animal/hostile/snake{
-	layer = 3.8;
-	name = "tree jumping viper"
-	},
-/turf/simulated/floor/asteroid/dirt/mud,
-/area/nadezhda/outside/forest/beast_cave_light)
+/obj/structure/bed,
+/obj/random/furniture/bedsheet,
+/obj/random/mob/voidwolf/low_chance,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/outside/forest/beast_cave_dark)
 "Wh" = (
 /obj/effect/spider/stickyweb,
 /obj/effect/decal/cleanable/rubble,
@@ -8269,10 +8201,6 @@
 /obj/structure/flora/small/trailrockb4,
 /turf/simulated/floor/rock/grey,
 /area/nadezhda/outside/forest/beast_cave_dark)
-"Zo" = (
-/mob/living/simple_animal/hostile/frog,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/outside/forest/beast_cave_light)
 "Zu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
@@ -10726,7 +10654,7 @@ dS
 dS
 rH
 rK
-rS
+sa
 rY
 sd
 sd
@@ -11942,7 +11870,7 @@ rM
 rM
 rM
 sf
-sk
+rU
 so
 rM
 rM
@@ -12745,7 +12673,7 @@ et
 et
 et
 rI
-rQ
+et
 et
 et
 iw
@@ -13441,7 +13369,7 @@ dS
 dS
 iJ
 jk
-af
+lw
 af
 af
 iT
@@ -14021,7 +13949,7 @@ rK
 rM
 tf
 sJ
-eX
+rZ
 rK
 rK
 aa
@@ -14160,7 +14088,7 @@ et
 et
 iw
 iw
-fu
+sk
 et
 et
 et
@@ -14368,7 +14296,7 @@ iw
 et
 et
 dS
-rE
+et
 iw
 et
 et
@@ -14827,7 +14755,7 @@ rK
 rM
 eG
 rZ
-eX
+rZ
 rZ
 rZ
 te
@@ -14854,7 +14782,7 @@ gB
 dS
 iK
 iY
-jp
+bt
 af
 iz
 kl
@@ -16114,7 +16042,7 @@ Qy
 PY
 PY
 HX
-PY
+Wj
 PY
 PY
 Mk
@@ -16717,7 +16645,7 @@ ww
 PY
 PY
 Af
-PY
+Wj
 Qk
 PY
 XZ
@@ -17256,7 +17184,7 @@ eh
 eh
 eh
 ej
-ej
+ez
 ej
 eh
 xW
@@ -17524,10 +17452,10 @@ dS
 dS
 LY
 PY
-et
+hu
 Zh
 et
-et
+hu
 et
 et
 Af
@@ -17727,10 +17655,10 @@ Cr
 et
 et
 et
+hu
 et
 et
-et
-et
+hu
 Zh
 et
 el
@@ -18339,7 +18267,7 @@ hu
 et
 et
 et
-oO
+et
 iw
 et
 eJ
@@ -18534,7 +18462,7 @@ dS
 dS
 hu
 fC
-oO
+et
 et
 et
 fC
@@ -18596,7 +18524,7 @@ rv
 tz
 qO
 qO
-qO
+jP
 rK
 rK
 rK
@@ -18690,7 +18618,7 @@ dS
 ey
 iw
 eE
-et
+hu
 et
 et
 jc
@@ -18797,7 +18725,7 @@ ro
 rv
 tA
 tD
-tD
+Wg
 tD
 rK
 rK
@@ -18865,7 +18793,7 @@ dS
 ej
 eh
 ej
-ej
+ez
 ej
 ej
 ej
@@ -18890,7 +18818,7 @@ gP
 fh
 dS
 et
-iw
+hu
 et
 iw
 eE
@@ -19088,7 +19016,7 @@ gy
 gP
 gK
 gP
-iM
+gJ
 dS
 dS
 et
@@ -19149,7 +19077,7 @@ fu
 et
 et
 iw
-et
+oO
 iw
 iw
 es
@@ -19275,7 +19203,7 @@ ej
 ej
 eh
 ej
-ej
+ez
 ej
 ej
 eq
@@ -19359,7 +19287,7 @@ oX
 et
 et
 fC
-et
+hu
 Kp
 Qj
 Qj
@@ -19545,7 +19473,7 @@ dS
 fu
 eJ
 iw
-et
+oO
 iw
 et
 eJ
@@ -19559,7 +19487,7 @@ iw
 et
 pq
 eJ
-et
+hu
 iw
 et
 Qj
@@ -19694,7 +19622,7 @@ yA
 gy
 gL
 gy
-lJ
+gC
 iq
 dS
 dS
@@ -19763,7 +19691,7 @@ oW
 et
 fC
 et
-et
+hu
 Qj
 Qj
 Qj
@@ -20005,7 +19933,7 @@ Aw
 cp
 Fr
 Aw
-rq
+qS
 sd
 rn
 qS
@@ -20169,7 +20097,7 @@ et
 px
 pu
 CO
-Zo
+CO
 CO
 CO
 CO
@@ -20204,7 +20132,7 @@ se
 sy
 ag
 qZ
-rd
+Aw
 ag
 bm
 sd
@@ -20828,7 +20756,7 @@ bL
 bL
 bL
 et
-et
+io
 et
 iw
 jH
@@ -21328,7 +21256,7 @@ af
 jk
 jk
 jk
-JL
+af
 iW
 St
 bn
@@ -21380,8 +21308,8 @@ iw
 et
 et
 dS
-pA
-pK
+cC
+cC
 pH
 gy
 Qj
@@ -21433,10 +21361,10 @@ aC
 rJ
 aG
 aI
+aa
 et
 et
 et
-io
 iw
 iw
 et
@@ -21635,7 +21563,7 @@ aB
 aC
 aG
 aC
-et
+ad
 et
 iw
 oW
@@ -21664,7 +21592,7 @@ rH
 rH
 VJ
 zM
-Cf
+Om
 pI
 vC
 an
@@ -21837,7 +21765,7 @@ aG
 rJ
 aG
 cs
-iw
+rd
 fu
 et
 iw
@@ -22038,8 +21966,8 @@ aB
 aC
 aC
 rF
-aG
-et
+bn
+bn
 et
 et
 es
@@ -22133,7 +22061,7 @@ kc
 jc
 et
 af
-Wg
+gy
 jq
 zD
 xW
@@ -22506,7 +22434,7 @@ ej
 ej
 ej
 ej
-ej
+ez
 en
 ej
 ej
@@ -23276,7 +23204,7 @@ rH
 aK
 rU
 uu
-bs
+GZ
 VJ
 VJ
 zM
@@ -23492,7 +23420,7 @@ ZU
 ZU
 In
 ZU
-vx
+ZU
 UL
 rK
 rK
@@ -23722,7 +23650,7 @@ ej
 ej
 ej
 eq
-ej
+ez
 en
 xW
 xW
@@ -24167,7 +24095,7 @@ rH
 rK
 rK
 rV
-aA
+rZ
 nO
 rM
 rU
@@ -24319,7 +24247,7 @@ dS
 em
 ej
 ej
-ej
+ez
 eh
 ej
 eh
@@ -24978,7 +24906,7 @@ an
 sy
 sj
 se
-oh
+sd
 ld
 rU
 rK
@@ -26125,7 +26053,7 @@ ag
 rZ
 rU
 bm
-tV
+rZ
 rH
 sl
 sl
@@ -28158,7 +28086,7 @@ ek
 xW
 et
 eM
-io
+et
 et
 KC
 JX
@@ -28354,7 +28282,7 @@ rK
 rH
 dS
 ei
-eh
+iM
 ej
 eh
 xW
@@ -29152,7 +29080,7 @@ uu
 rH
 rH
 rH
-rU
+vx
 bm
 bj
 rK
@@ -29962,7 +29890,7 @@ rH
 rH
 rZ
 aZ
-sd
+rS
 rK
 rK
 rK
@@ -32238,7 +32166,7 @@ rK
 rK
 rK
 ji
-jP
+ji
 ji
 ji
 ji
@@ -33040,7 +32968,7 @@ rK
 rK
 lf
 ji
-ji
+tX
 ji
 ji
 ji
@@ -33652,7 +33580,7 @@ ji
 jw
 jv
 jC
-SH
+jw
 jw
 ls
 jw
@@ -33846,7 +33774,7 @@ rH
 rK
 rK
 ji
-jP
+ji
 ji
 jE
 ji
@@ -35061,7 +34989,7 @@ ji
 lh
 jw
 ji
-jP
+tX
 ji
 ji
 Nb
@@ -36077,7 +36005,7 @@ ji
 ji
 ji
 ji
-jj
+eX
 ji
 jv
 sv
@@ -36878,7 +36806,7 @@ jw
 ji
 ji
 jw
-jP
+ji
 jj
 ji
 ji
@@ -37685,7 +37613,7 @@ ji
 jw
 ji
 ji
-jw
+Hj
 jw
 ji
 ji
@@ -38286,12 +38214,12 @@ bn
 bn
 xy
 ji
-jP
 ji
 ji
 ji
 ji
-jP
+ji
+ji
 ji
 jw
 ji
@@ -43329,7 +43257,7 @@ DK
 gI
 fC
 DK
-Hj
+gc
 hd
 gf
 JH

--- a/maps/_DeepForest/map/_Deep_Forest.dmm
+++ b/maps/_DeepForest/map/_Deep_Forest.dmm
@@ -1336,6 +1336,10 @@
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
 	name = "Abandoned Bunker"
 	})
+"aQK" = (
+/obj/random/mob/roaches/low_chance,
+/turf/simulated/floor/asteroid/grass/dry,
+/area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "aRj" = (
 /obj/effect/floor_decal/corner_oldtile/white{
 	dir = 1
@@ -1673,13 +1677,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
 "beH" = (
-/mob/living/simple_animal/hostile/diyaab,
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
+/obj/random/ammo_lowcost/low_chance,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/meadow)
 "beQ" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/wood/wild5,
@@ -2332,13 +2332,13 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/random/cluster/roaches,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
 	pixel_x = 0
 	},
+/obj/random/cluster/spiders,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "bzR" = (
@@ -5672,9 +5672,9 @@
 /turf/simulated/mineral/planet,
 /area/nadezhda/outside/meadow)
 "dyj" = (
-/obj/random/cluster/roaches,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/dungeon/outside/prepper/vault/floor3)
+/obj/random/cluster/roaches/low_chance,
+/turf/simulated/floor/wood,
+/area/nadezhda/dungeon/outside/prepper)
 "dyp" = (
 /obj/item/remains,
 /turf/simulated/floor/tiled/steel/danger,
@@ -7616,9 +7616,10 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
 "eNx" = (
-/obj/random/mob/spiders,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/smuggler_zone_u)
+/obj/item/remains/tajaran,
+/obj/random/mob/roaches,
+/turf/simulated/floor/asteroid/grass/dry,
+/area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "eNI" = (
 /obj/structure/catwalk,
 /obj/structure/closet/random_tech,
@@ -7763,9 +7764,9 @@
 /turf/simulated/floor/beach/sand/desert,
 /area/nadezhda/dungeon/outside/zoo)
 "eSz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/mob/roaches,
-/turf/simulated/floor/tiled/dark/brown_perforated,
+/obj/random/mob/roaches/low_chance,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/asteroid/grass/dry,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "eSN" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9005,6 +9006,7 @@
 "fHx" = (
 /obj/structure/flora/small/lavarock1,
 /obj/random/spider_trap_burrowing/low_chance,
+/obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/asteroid/rogue)
 "fHG" = (
@@ -10157,6 +10159,10 @@
 	name = "Loading Crane"
 	},
 /area/nadezhda/dungeon/outside/prepper/delta)
+"gtC" = (
+/obj/random/cluster/roaches/lower_chance,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "gtH" = (
 /obj/structure/table/woodentable,
 /obj/item/oddity/common/coin,
@@ -11224,11 +11230,10 @@
 /turf/simulated/floor/wood/wild5,
 /area/colony/exposedsun/pastgate)
 "hbf" = (
-/obj/random/mob/croaker/low_chance,
-/obj/effect/overlay/water,
-/obj/effect/overlay/water/top,
-/turf/simulated/floor/beach/water/jungle,
-/area/nadezhda/outside/meadow)
+/obj/effect/decal/cleanable/dirt,
+/obj/random/cluster/roaches/low_chance,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/dungeon/outside/prepper)
 "hbk" = (
 /obj/item/trash/cigbutt/fortress,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
@@ -11518,7 +11523,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/random/cluster/roaches,
+/obj/random/cluster/spiders,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "hkf" = (
@@ -12339,9 +12344,9 @@
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
 "hHu" = (
-/obj/random/cluster/roaches,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
+/obj/item/remains/tajaran,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/asteroid/grass/dry,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "hHx" = (
 /obj/effect/decal/cleanable/dirt,
@@ -12497,9 +12502,9 @@
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
 "hOd" = (
-/obj/random/cluster/roaches/low_chance,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/dungeon/outside/prepper)
+/obj/random/mob/roaches,
+/turf/simulated/floor/asteroid/grass/dry,
+/area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "hOe" = (
 /obj/item/oddity/common/paper_bundle,
 /obj/effect/decal/cleanable/dirt,
@@ -12694,11 +12699,9 @@
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/dungeon/outside/prepper/delta)
 "hSP" = (
-/obj/random/cluster/roaches/low_chance,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/bluecorner,
-/area/nadezhda/dungeon/outside/prepper)
+/obj/random/cluster/roaches,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "hTg" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet,
@@ -13093,6 +13096,11 @@
 /obj/random/scrap/dense_weighted,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"ifN" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/structure/boulder,
+/turf/simulated/floor/rock/grey,
+/area/asteroid/rogue)
 "ifS" = (
 /obj/structure/closet/random_hostilemobs,
 /obj/effect/decal/cleanable/dirt,
@@ -14097,10 +14105,10 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
 "iKk" = (
-/obj/random/cluster/roaches/low_chance,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/dungeon/outside/prepper)
+/mob/living/simple_animal/hostile/creature/tissue,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/dungeon/outside/prepper/lima)
 "iKn" = (
 /obj/random/junk,
 /turf/simulated/floor/plating/under,
@@ -16234,8 +16242,8 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
 "khw" = (
-/obj/random/mob/roaches/low_chance,
-/turf/simulated/floor/tiled/dark/brown_perforated,
+/obj/random/cluster/roaches/low_chance,
+/turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "khL" = (
 /obj/effect/decal/cleanable/dirt,
@@ -17631,13 +17639,13 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/random/cluster/roaches,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
 	pixel_y = 0
 	},
+/obj/random/cluster/spiders,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "lcK" = (
@@ -18606,6 +18614,7 @@
 /area/nadezhda/dungeon/outside/prepper/delta)
 "lLH" = (
 /obj/structure/bed,
+/obj/random/mob/vox/low_chance,
 /turf/simulated/floor/wood/wild5,
 /area/colony/exposedsun/pastgate)
 "lLS" = (
@@ -19216,6 +19225,11 @@
 /obj/random/gun_parts/high_end,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/prepper/lima)
+"mfM" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "mfP" = (
 /obj/structure/catwalk,
 /obj/structure/closet/random_spareparts,
@@ -20531,6 +20545,10 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"mTk" = (
+/obj/random/cluster/roaches/low_chance,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/dungeon/outside/prepper)
 "mTD" = (
 /obj/structure/railing/grey{
 	dir = 1
@@ -27026,9 +27044,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "qOk" = (
-/obj/random/mob/roaches,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/dungeon/outside/prepper/vault/floor3)
+/obj/structure/boulder,
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/asteroid/rogue)
 "qOl" = (
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/dark/gray_platform,
@@ -27712,6 +27731,11 @@
 	name = "Abandoned Outpost";
 	narrate = "This building seems to have been quickly fabricated within the depths of the small rocky hill over it. Whoever made it seems to have fled, as the interior seems both roughened by fighting, but also completely abandoned, with machines either falling into disarray or intentionally sabotaged along with the rest of the outpost."
 	})
+"riT" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/small/grassa4,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/meadow)
 "rjb" = (
 /obj/machinery/light/floor,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
@@ -30131,7 +30155,7 @@
 /turf/simulated/floor/beach/water/flooded,
 /area/nadezhda/dungeon/outside/prepper/delta)
 "sFD" = (
-/obj/random/mob/prepper,
+/obj/random/cluster/roaches/low_chance,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/dungeon/outside/prepper)
 "sFI" = (
@@ -30657,7 +30681,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/random/cluster/roaches,
+/obj/random/cluster/spiders,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "tbF" = (
@@ -31115,9 +31139,10 @@
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/delta)
 "toy" = (
-/obj/random/mob/prepper,
-/turf/simulated/floor/wood,
-/area/nadezhda/dungeon/outside/prepper)
+/obj/structure/flora/big/bush3,
+/obj/random/ammo_lowcost/low_chance,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/meadow)
 "toE" = (
 /obj/random/turret,
 /turf/simulated/floor/wood/wild5,
@@ -32447,13 +32472,13 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/random/cluster/roaches,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
 	pixel_y = 0
 	},
+/obj/random/cluster/spiders,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "ueX" = (
@@ -32623,6 +32648,13 @@
 /obj/landmark/join/start/outsider,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"ujo" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/random/mob/roaches/low_chance,
+/turf/simulated/floor/asteroid/grass/dry,
+/area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "ujP" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -37100,6 +37132,7 @@
 	dir = 4;
 	pixel_x = 8
 	},
+/obj/random/mob/vox/low_chance,
 /turf/simulated/floor/wood/wild5,
 /area/colony/exposedsun/pastgate)
 "xmn" = (
@@ -37316,6 +37349,7 @@
 	})
 "xrG" = (
 /obj/landmark/storyevent/midgame_stash_spawn,
+/obj/random/cluster/roaches/low_chance,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/dungeon/outside/prepper)
 "xrI" = (
@@ -42235,7 +42269,7 @@ dQF
 dQF
 dQF
 dQF
-bTm
+fcE
 bTm
 bTm
 dQF
@@ -42334,7 +42368,7 @@ bbg
 bbg
 bbg
 bbg
-eNx
+bbg
 bbg
 bbg
 bbg
@@ -42444,8 +42478,8 @@ dQF
 dQF
 dQF
 fHx
-bTm
-bTm
+qOk
+fcE
 bTm
 bTm
 dQF
@@ -42651,8 +42685,8 @@ dQF
 dQF
 bTm
 bTm
-bTm
-bTm
+fcE
+qOk
 dQF
 dQF
 bTm
@@ -42861,7 +42895,7 @@ bTm
 bTm
 bTm
 wZR
-bTm
+fcE
 dQF
 dQF
 bTm
@@ -42962,7 +42996,7 @@ tzx
 iSH
 bbg
 bbg
-eNx
+bbg
 iSH
 qbU
 qbU
@@ -53466,7 +53500,7 @@ qbU
 qbU
 qbU
 qbU
-ugY
+sRz
 qbU
 qbU
 qbU
@@ -57011,7 +57045,7 @@ ugY
 qbU
 qbU
 qbU
-euc
+jkn
 rel
 qbU
 qbU
@@ -57220,7 +57254,7 @@ qbU
 qbU
 qbU
 qbU
-ugY
+wXs
 ugY
 qbU
 qbU
@@ -57847,7 +57881,7 @@ qbU
 qbU
 qbU
 euc
-ugY
+wXs
 qbU
 qbU
 euc
@@ -58058,7 +58092,7 @@ qbU
 rel
 qkQ
 fWH
-ugY
+ojy
 ugY
 ugY
 ugY
@@ -58670,7 +58704,7 @@ euc
 qbU
 qbU
 qbU
-ify
+ifN
 ify
 nJw
 rel
@@ -58889,7 +58923,7 @@ qbU
 qbU
 qbU
 euc
-sLE
+euc
 euc
 qbU
 qbU
@@ -59739,7 +59773,7 @@ qbU
 qbU
 qbU
 euc
-euc
+xBq
 qbU
 qbU
 qbU
@@ -59948,7 +59982,7 @@ qPR
 rUt
 qbU
 qbU
-euc
+xBq
 qbU
 qbU
 qbU
@@ -60150,7 +60184,7 @@ qbU
 euc
 euc
 xTR
-euc
+xBq
 sLE
 euc
 euc
@@ -60571,8 +60605,8 @@ qbU
 rUt
 euc
 euc
-euc
-euc
+jkn
+sLE
 qbU
 qbU
 qbU
@@ -60785,7 +60819,7 @@ qbU
 qbU
 qbU
 euc
-euc
+sLE
 qbU
 qbU
 xBq
@@ -61200,7 +61234,7 @@ qbU
 qbU
 qbU
 euc
-euc
+sLE
 qbU
 qbU
 qbU
@@ -63149,9 +63183,9 @@ qbU
 qbU
 euc
 euc
-euc
+xBq
 xAR
-ugY
+ojy
 ugY
 qbU
 qbU
@@ -63355,7 +63389,7 @@ qbU
 qbU
 qbU
 qbU
-ugY
+ojy
 ugY
 euc
 qbU
@@ -63564,7 +63598,7 @@ qbU
 qbU
 qbU
 jkn
-ugY
+ojy
 qbU
 qbU
 qbU
@@ -66727,7 +66761,7 @@ coU
 idB
 hpw
 jCD
-eTv
+hpw
 idB
 sZr
 oGU
@@ -67352,7 +67386,7 @@ tEX
 rVv
 idB
 idB
-eTv
+hpw
 jCD
 hpw
 idB
@@ -68573,14 +68607,14 @@ qbU
 qbU
 qbU
 qbU
-euc
+xBq
 xBq
 qbU
 qbU
 qbU
 qbU
-ugY
-ugY
+sRz
+sRz
 qbU
 qbU
 qbU
@@ -68711,7 +68745,7 @@ oNj
 kfH
 aHN
 fIb
-beH
+izA
 pFf
 kdd
 hwy
@@ -69294,7 +69328,7 @@ usK
 gcg
 usK
 usK
-dyj
+nrh
 wIV
 oya
 nrh
@@ -69307,7 +69341,7 @@ nrh
 nrh
 dPZ
 jNa
-dRb
+khw
 kdx
 jNa
 coU
@@ -69505,7 +69539,7 @@ bIO
 usK
 anr
 uBg
-dyj
+nrh
 nrh
 nrh
 tFh
@@ -69687,7 +69721,7 @@ oIB
 oVF
 tFh
 lUu
-qOk
+nrh
 jNa
 tFh
 tFh
@@ -69886,8 +69920,8 @@ coU
 coU
 coU
 jNa
-wyl
-kXU
+hOd
+hHu
 qrT
 tFh
 tFh
@@ -69895,7 +69929,7 @@ oIB
 tFh
 mWx
 nrh
-wOH
+nrh
 nrh
 jNa
 xfb
@@ -70096,9 +70130,9 @@ coU
 coU
 jNa
 gdR
-wyl
+aQK
 ylJ
-tFh
+oIB
 tFh
 nrh
 tFh
@@ -70143,7 +70177,7 @@ dZD
 bIO
 nrh
 jNa
-dRb
+gtC
 kdx
 jNa
 coU
@@ -70514,10 +70548,10 @@ coU
 coU
 jNa
 gdR
-wyl
+eSz
 ylJ
 nrh
-mNN
+mfM
 tFh
 tFh
 jNa
@@ -70726,7 +70760,7 @@ wyl
 wyl
 ylJ
 tFh
-nrh
+wOH
 tFh
 oIB
 jNa
@@ -70931,8 +70965,8 @@ coU
 coU
 coU
 jNa
-gdR
-kXU
+ujo
+eNx
 kXU
 pRi
 trl
@@ -70979,7 +71013,7 @@ tFh
 mCk
 xMU
 jNa
-dRb
+khw
 dRb
 jNa
 coU
@@ -71144,14 +71178,14 @@ wyl
 wyl
 wyl
 wyl
-kXU
-wyl
-wyl
+hHu
+aQK
+hOd
 jNa
 xkx
 wCK
-qOk
-wOH
+nrh
+nrh
 dhy
 ayu
 cYn
@@ -71352,7 +71386,7 @@ jNa
 kXU
 pZK
 wyl
-wyl
+hOd
 cEB
 kXU
 wyl
@@ -71568,7 +71602,7 @@ jNa
 jNa
 jNf
 ayu
-khw
+nAt
 ayu
 onN
 jNa
@@ -71596,7 +71630,7 @@ jNa
 nrh
 ftX
 tFh
-hHu
+tFh
 nrh
 nrh
 tFh
@@ -71776,7 +71810,7 @@ coU
 coU
 jNa
 jNf
-eSz
+ayu
 nAt
 ayu
 tMq
@@ -71815,7 +71849,7 @@ kwb
 nrh
 tFh
 jNa
-dRb
+hSP
 vRn
 jNa
 coU
@@ -72011,7 +72045,7 @@ nrh
 nrh
 jNa
 jNa
-dyj
+nrh
 nrh
 nrh
 tFh
@@ -72361,7 +72395,7 @@ daI
 daI
 jVK
 idB
-kHB
+iKk
 kHB
 kHB
 kHB
@@ -72651,7 +72685,7 @@ nrh
 vAW
 nrh
 jNa
-dRb
+gtC
 oEy
 jNa
 coU
@@ -73408,7 +73442,7 @@ jVK
 idB
 kHB
 kHB
-kHB
+iKk
 kHB
 kHB
 idB
@@ -80821,13 +80855,13 @@ nxY
 rHY
 qHH
 oCD
-dCW
+sFD
 dCW
 mMP
 qHH
 qHH
 kxO
-hOd
+cpY
 cpY
 cpY
 cpY
@@ -81448,7 +81482,7 @@ nxY
 rHY
 qHH
 bmp
-toy
+iHg
 tjr
 unP
 qHH
@@ -81457,7 +81491,7 @@ nVZ
 cpY
 ioO
 ioO
-hOd
+cpY
 nVZ
 qHH
 dBe
@@ -81657,7 +81691,7 @@ nxY
 rHY
 qHH
 dmC
-iHg
+dyj
 iHg
 jyJ
 qHH
@@ -82499,7 +82533,7 @@ rIF
 qHH
 qHH
 cbi
-hOd
+cpY
 cpY
 cpY
 cpY
@@ -84596,7 +84630,7 @@ qHH
 dya
 rIF
 rIF
-suL
+hbf
 qHH
 qHH
 llJ
@@ -84800,10 +84834,10 @@ cpY
 sQm
 ugf
 ugf
-apc
+nhq
 kGd
 suL
-cHm
+rIF
 xrG
 aZu
 qHH
@@ -85012,7 +85046,7 @@ apc
 xdS
 qHH
 vom
-rIF
+mTk
 suL
 rIF
 qHH
@@ -87102,14 +87136,14 @@ nhq
 iwj
 xri
 hXA
-iKk
+apc
 apc
 iwj
 iwj
 apc
 hXA
 apc
-iKk
+apc
 qHH
 alu
 uam
@@ -87511,7 +87545,7 @@ qHH
 eJH
 nhq
 wwf
-iKk
+apc
 apc
 hXA
 xri
@@ -88553,7 +88587,7 @@ nxY
 nxY
 rHY
 qHH
-hOd
+cpY
 bun
 ogc
 vhj
@@ -89620,7 +89654,7 @@ nMn
 nMn
 nMn
 rRu
-hSP
+nMn
 eno
 qHH
 qHH
@@ -89759,7 +89793,7 @@ chp
 chp
 hRb
 afB
-hRL
+iVK
 hRL
 hRL
 nqw
@@ -89824,7 +89858,7 @@ liI
 cZD
 nMn
 nMn
-hSP
+nMn
 nMn
 vTX
 vTX
@@ -90453,7 +90487,7 @@ rYj
 nMn
 nMn
 rRu
-hSP
+nMn
 rRu
 nMn
 dUH
@@ -94779,7 +94813,7 @@ hRL
 hRL
 hRL
 hRL
-hRL
+iVK
 hRL
 hRL
 hRL
@@ -97089,7 +97123,7 @@ hRL
 iVK
 wFt
 wFt
-vQt
+hRL
 wFt
 wFt
 hRL
@@ -99474,7 +99508,7 @@ qxe
 gWu
 jQU
 wMg
-pHN
+hRL
 hRL
 hRL
 jLb
@@ -99686,7 +99720,7 @@ hRL
 hRL
 hRL
 hRL
-pHN
+hRL
 wFt
 wFt
 wFt
@@ -99803,7 +99837,7 @@ ngf
 ngf
 hRL
 wPw
-hRL
+dqw
 hRL
 hRL
 hRL
@@ -99891,9 +99925,9 @@ qxe
 hRL
 hRL
 hRL
-pHN
 hRL
-pHN
+hRL
+hRL
 hRL
 wFt
 wFt
@@ -100103,9 +100137,9 @@ hRL
 fon
 fon
 hRL
-pHN
 hRL
-pHN
+hRL
+hRL
 wFt
 wFt
 wFt
@@ -100522,7 +100556,7 @@ naj
 naj
 naj
 hRL
-pHN
+hRL
 hRL
 hRL
 hRL
@@ -101272,7 +101306,7 @@ dWh
 hRL
 hRL
 hRL
-pHN
+hRL
 hRL
 hRL
 hRL
@@ -102108,7 +102142,7 @@ hRL
 hRL
 hRL
 hRL
-hRL
+pHN
 hRL
 hRL
 hRL
@@ -104909,7 +104943,7 @@ naj
 naj
 hdj
 jLb
-hRL
+pHN
 hRL
 hRL
 hRL
@@ -105120,9 +105154,9 @@ hdj
 jLb
 jLb
 wPw
+pHN
 hRL
-hRL
-hRL
+pHN
 hRL
 jLb
 naj
@@ -105326,14 +105360,14 @@ rqD
 naj
 naj
 ejL
-boc
+aXb
 tMk
 jLb
 hRL
 hRL
 hRL
 hRL
-hRL
+pHN
 fiZ
 naj
 naj
@@ -105539,7 +105573,7 @@ auW
 jLb
 jLb
 hRL
-hRL
+pHN
 hRL
 hRL
 hRL
@@ -105750,7 +105784,7 @@ iGi
 kmL
 qxe
 hRL
-hRL
+pHN
 hRL
 hRL
 rBW
@@ -108506,7 +108540,7 @@ hRL
 dKD
 qxe
 qxe
-rPB
+hRL
 hRL
 hRL
 hRL
@@ -109763,7 +109797,7 @@ siG
 hRL
 lXi
 hRL
-hRL
+fps
 hRL
 ngf
 pPK
@@ -110389,9 +110423,9 @@ rFd
 cmS
 aMy
 jLb
-hRL
-hRL
-hRL
+fps
+sBG
+sBG
 naj
 naj
 naj
@@ -110598,9 +110632,9 @@ naj
 xOU
 ngf
 jLb
-jLb
+sBG
 hRL
-hRL
+sBG
 naj
 naj
 naj
@@ -110806,8 +110840,8 @@ naj
 naj
 naj
 naj
-siG
-vag
+sBG
+riT
 hRL
 hRL
 naj
@@ -111017,8 +111051,8 @@ naj
 naj
 eZo
 siG
-hRL
-hRL
+rPB
+beH
 qma
 naj
 fiZ
@@ -111226,8 +111260,8 @@ naj
 naj
 eZo
 sBG
-hRL
-sBG
+beH
+toy
 qxe
 qxe
 qxe
@@ -111824,7 +111858,7 @@ hRL
 kvE
 ffM
 axM
-hbf
+axM
 axM
 mCw
 mIS
@@ -111971,7 +112005,7 @@ hRL
 hRL
 hRL
 iVK
-hRL
+pHN
 hRL
 hRL
 hRL
@@ -111989,7 +112023,7 @@ naj
 fiZ
 lLf
 hRL
-hRL
+pHN
 oqk
 fVY
 rBW
@@ -112404,13 +112438,13 @@ naj
 naj
 hpi
 rBW
-oqk
+euM
 hRL
 hRL
 fVY
 oqk
 afB
-hRL
+pHN
 hRL
 hRL
 iVK
@@ -112823,7 +112857,7 @@ naj
 hRL
 fVY
 afB
-hRL
+pHN
 hRL
 hRL
 oqk
@@ -114908,7 +114942,7 @@ boc
 hRL
 hRL
 hRL
-pHN
+hRL
 hRL
 eZo
 naj
@@ -115536,7 +115570,7 @@ afB
 boc
 hRL
 wFt
-pHN
+hRL
 afB
 hRL
 hRL
@@ -115747,7 +115781,7 @@ hRL
 wFt
 hRL
 hRL
-pHN
+hRL
 hRL
 fiZ
 gva
@@ -116367,7 +116401,7 @@ ygj
 dRn
 fke
 hRL
-pHN
+hRL
 hRL
 wFt
 wFt

--- a/maps/_DeepForest/map/_Greyson_Field_Office.dmm
+++ b/maps/_DeepForest/map/_Greyson_Field_Office.dmm
@@ -2199,6 +2199,11 @@
 /obj/item/ammo_casing/magnum_40/spent,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star/fo_internal)
+"rL" = (
+/obj/random/cluster/roaches/low_chance,
+/obj/random/cluster/roaches/low_chance,
+/turf/simulated/floor/rock/manmade/road,
+/area/nadezhda/outside/one_star/fo_outside)
 "rO" = (
 /obj/structure/bed/chair/comfy/beige,
 /turf/simulated/floor/tiled/white/cargo,
@@ -6031,6 +6036,10 @@
 	},
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/outside/one_star/fo_outside)
+"VN" = (
+/obj/random/cluster/roaches/low_chance,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/one_star/fo_outside)
 "VO" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/railing/grey,
@@ -6390,7 +6399,7 @@
 /turf/simulated/floor/reinforced,
 /area/nadezhda/outside/one_star/fo_internal)
 "Yr" = (
-/obj/random/cluster/roaches,
+/obj/random/cluster/roaches/low_chance,
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/one_star/fo_outside)
 "Ys" = (
@@ -6798,7 +6807,7 @@ wK
 Rl
 Re
 Re
-PN
+VN
 PN
 PN
 PN
@@ -6832,7 +6841,7 @@ PN
 cF
 cF
 Yr
-cF
+Yr
 cF
 PN
 PN
@@ -6949,9 +6958,7 @@ Je
 MV
 rB
 Yr
-Yr
-cF
-cF
+rL
 cF
 cF
 cF
@@ -6970,6 +6977,8 @@ cF
 cF
 Yr
 Yr
+Yr
+cF
 cF
 cF
 cF

--- a/maps/_DeepForest/map/_Prepper_Bunker.dmm
+++ b/maps/_DeepForest/map/_Prepper_Bunker.dmm
@@ -1163,6 +1163,10 @@
 /obj/random/rig_module,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
+"fQ" = (
+/obj/random/cluster/roaches/lower_chance,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "fV" = (
 /obj/structure/railing/grey{
 	dir = 1
@@ -1954,6 +1958,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
+/obj/random/cluster/roaches_hoard,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "kG" = (
@@ -3672,7 +3677,7 @@
 "sc" = (
 /obj/random/cluster/roaches,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/dungeon/outside/prepper/vault/floor3)
+/area/nadezhda/dungeon/outside/prepper/vault/floor4)
 "sd" = (
 /obj/item/material/shard,
 /turf/simulated/floor/tiled/dark,
@@ -4357,8 +4362,7 @@
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "tS" = (
 /obj/random/cluster/roaches,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "tV" = (
 /obj/machinery/light/small,
@@ -6266,6 +6270,11 @@
 /obj/random/contraband/low_chance,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"BS" = (
+/obj/effect/decal/cleanable/filth,
+/obj/random/cluster/roaches/lower_chance,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/dungeon/outside/prepper/vault/floor4)
 "BU" = (
 /obj/machinery/door/airlock,
 /turf/simulated/floor/tiled/dark,
@@ -6349,10 +6358,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
 "CD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/mob/prepper,
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/dungeon/outside/prepper/vault/floor3)
+/obj/effect/decal/cleanable/rubble,
+/obj/random/cluster/roaches/lower_chance,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/dungeon/outside/prepper/vault/floor4)
 "CE" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -7289,9 +7298,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
 "Gm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/mob/prepper_boss_lowchance,
-/turf/simulated/floor/tiled/dark,
+/obj/random/cluster/roaches/lower_chance,
+/turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
 "Gn" = (
 /obj/machinery/recharge_station,
@@ -7825,9 +7833,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
 "Ii" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/cluster/roaches,
+/obj/random/cluster/roaches/lower_chance,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
 "Ij" = (
@@ -9367,7 +9373,7 @@ Ms
 Ms
 Gc
 yg
-Gm
+yq
 yg
 yg
 yq
@@ -9376,7 +9382,7 @@ yq
 Gw
 GI
 yq
-yg
+sc
 HT
 yg
 yg
@@ -9738,7 +9744,7 @@ yg
 yg
 yg
 yq
-Ii
+Cb
 Fe
 Iw
 Hw
@@ -9823,7 +9829,7 @@ Ms
 yg
 GT
 yq
-yg
+Ii
 yq
 Hz
 yQ
@@ -10380,7 +10386,7 @@ HZ
 HZ
 IG
 IG
-Iz
+Gm
 II
 Ju
 HZ
@@ -11002,7 +11008,7 @@ HN
 HO
 IB
 II
-IP
+BS
 HZ
 HZ
 HZ
@@ -11014,7 +11020,7 @@ HZ
 IG
 IG
 IG
-IG
+CD
 IG
 Jt
 aa
@@ -11173,7 +11179,7 @@ yq
 yg
 yg
 yg
-Hb
+yq
 yq
 HD
 HO
@@ -14693,9 +14699,9 @@ ho
 hG
 hb
 hb
-Mo
+ho
 aw
-YC
+fQ
 ke
 aw
 aa
@@ -15042,7 +15048,7 @@ aw
 aw
 aw
 aw
-sc
+hb
 sC
 Zo
 ho
@@ -15051,7 +15057,7 @@ ho
 ho
 ho
 hG
-CD
+zK
 uM
 hb
 aw
@@ -15134,7 +15140,7 @@ ab
 aw
 sd
 sD
-sc
+hb
 hb
 hb
 ho
@@ -15412,10 +15418,10 @@ ho
 ho
 hG
 zK
-RY
+hb
 hb
 aw
-YC
+fQ
 ke
 aw
 aa
@@ -15775,7 +15781,7 @@ ho
 QM
 iS
 aw
-YC
+tS
 YC
 aw
 aa
@@ -16035,7 +16041,7 @@ aw
 hb
 sG
 ho
-tS
+ho
 hb
 hb
 ho
@@ -16135,7 +16141,7 @@ gE
 hb
 ho
 aw
-YC
+tS
 xt
 aw
 aa
@@ -16212,7 +16218,7 @@ hb
 aw
 aw
 aw
-sc
+hb
 hb
 hb
 ho

--- a/maps/_DeepForest/map/_River_Forest.dmm
+++ b/maps/_DeepForest/map/_River_Forest.dmm
@@ -150,6 +150,12 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/forest/river_forest_underground)
+"aF" = (
+/obj/structure/table/onestar,
+/obj/item/stack/material/platinum/random,
+/obj/random/junkfood,
+/turf/simulated/floor/tiled/derelict,
+/area/nadezhda/outside/one_star/fo_internal)
 "aJ" = (
 /obj/structure/invislight,
 /obj/structure/flora/ausbushes/grassybush,
@@ -222,6 +228,10 @@
 /obj/machinery/portable_atmospherics/hydroponics/soil/invisible,
 /turf/unsimulated/mineral,
 /area/nadezhda/outside/forest/river_forest_light)
+"bJ" = (
+/obj/effect/decal/cleanable/ash,
+/turf/simulated/floor/tiled/derelict/white_small_edges,
+/area/nadezhda/outside/one_star/fo_internal)
 "bX" = (
 /obj/structure/bed/chair/janicart,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
@@ -274,9 +284,10 @@
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star/fo_internal)
 "cO" = (
-/mob/living/carbon/superior_animal/xenomorph/runner/panther,
-/turf/simulated/floor/tiled/derelict/white_small_edges,
-/area/nadezhda/outside/one_star/fo_internal)
+/obj/structure/scrap/medical/large,
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/rock/grey,
+/area/nadezhda/outside/forest/river_forest_underground)
 "cR" = (
 /obj/random/cluster/xenomorphs/lower_chance,
 /obj/effect/decal/cleanable/rubble,
@@ -362,7 +373,8 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest/river_forest_light)
 "ee" = (
-/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/rifle,
+/obj/effect/decal/cleanable/ash,
+/obj/effect/damagedfloor/fire,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star/fo_internal)
 "ei" = (
@@ -370,6 +382,12 @@
 /obj/random/mob/xenomorphs,
 /turf/simulated/floor/rock/dark,
 /area/nadezhda/outside/forest/river_forest_underground)
+"el" = (
+/obj/structure/table/onestar,
+/obj/item/reagent_containers/blood/OPlus,
+/obj/item/material/shard/shrapnel/scrap,
+/turf/simulated/floor/tiled/derelict,
+/area/nadezhda/outside/one_star/fo_internal)
 "en" = (
 /obj/structure/table/woodentable,
 /turf/simulated/floor/carpet/purcarpet,
@@ -381,6 +399,11 @@
 /obj/random/mob/mukwah,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/forest/river_forest_underground)
+"et" = (
+/obj/effect/damagedfloor/fire,
+/obj/effect/decal/cleanable/ash,
+/turf/simulated/floor/tiled/derelict,
+/area/nadezhda/outside/one_star/fo_internal)
 "eu" = (
 /turf/simulated/open,
 /area/nadezhda/outside/forest/river_forest_light)
@@ -421,12 +444,25 @@
 "fe" = (
 /obj/structure/table/gamblingtable,
 /obj/item/cardholder,
+/obj/effect/damagedfloor/fire,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
+/area/nadezhda/outside/one_star/fo_internal)
+"fi" = (
+/obj/effect/damagedfloor/fire,
+/obj/effect/damagedfloor/fire,
+/turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star/fo_internal)
 "fm" = (
 /obj/structure/boulder,
 /turf/simulated/floor/rock,
 /area/nadezhda/outside/forest/river_forest_underground)
+"fn" = (
+/obj/structure/bed/chair/custom/onestar/red{
+	dir = 4
+	},
+/obj/effect/damagedfloor/fire,
+/turf/simulated/floor/tiled/derelict/white_small_edges,
+/area/nadezhda/outside/one_star/fo_internal)
 "fp" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/bcarpet,
@@ -480,8 +516,8 @@
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/forest/river_forest_underground)
 "fW" = (
-/obj/item/stool,
-/obj/random/mob/roomba/range,
+/obj/random/mob/xenomorphs,
+/obj/effect/damagedfloor/fire,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star/fo_internal)
 "fX" = (
@@ -550,6 +586,10 @@
 /obj/random/traps,
 /turf/simulated/floor/beach/sand/drywater,
 /area/nadezhda/outside/forest/river_forest_lake)
+"hl" = (
+/obj/item/material/shard/shrapnel/scrap,
+/turf/simulated/floor/tiled/derelict,
+/area/nadezhda/outside/one_star/fo_internal)
 "hm" = (
 /obj/structure/flora/ausbushes/reedbush,
 /obj/random/traps,
@@ -632,6 +672,10 @@
 /obj/random/mob/mukwah,
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/outside/forest/river_forest_underground)
+"iw" = (
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/mineral/random/rogue,
+/area/nadezhda/outside/forest/river_forest_underground)
 "ix" = (
 /obj/item/stack/material/bone,
 /obj/effect/decal/cleanable/rubble,
@@ -699,6 +743,12 @@
 /obj/random/closet_tech,
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/outside/forest/river_forest_underground)
+"jS" = (
+/obj/random/mob/xenomorphs,
+/obj/effect/damagedfloor/fire,
+/obj/effect/damagedfloor/fire,
+/turf/simulated/floor/tiled/derelict/white_small_edges,
+/area/nadezhda/outside/one_star/fo_internal)
 "jU" = (
 /obj/structure/flora/ausbushes/reedbush,
 /turf/simulated/floor/asteroid/dirt/mud,
@@ -1009,6 +1059,10 @@
 /obj/item/reagent_containers/food/drinks/teapot,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest/river_forest_light)
+"nc" = (
+/obj/item/material/shard/shrapnel/scrap,
+/turf/simulated/floor/tiled/derelict/white_small_edges,
+/area/nadezhda/outside/one_star/fo_internal)
 "ne" = (
 /obj/item/oddity/common/old_knife,
 /turf/simulated/floor/rock/dark,
@@ -1168,6 +1222,12 @@
 /obj/item/stack/ore/glass,
 /turf/simulated/floor/rock/dark,
 /area/nadezhda/outside/forest/river_forest_light)
+"oM" = (
+/obj/effect/damagedfloor/fire,
+/obj/effect/damagedfloor/fire,
+/obj/effect/decal/cleanable/ash,
+/turf/simulated/floor/tiled/derelict/white_small_edges,
+/area/nadezhda/outside/one_star/fo_internal)
 "oN" = (
 /obj/random/mob/mukwah,
 /turf/simulated/floor/rock/grey,
@@ -1207,7 +1267,7 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest/river_forest_light)
 "pb" = (
-/mob/living/carbon/superior_animal/robot/greyson/roomba,
+/obj/effect/damagedfloor/fire,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star/fo_internal)
 "pf" = (
@@ -1271,6 +1331,12 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/rock/grey,
 /area/nadezhda/outside/forest/river_forest_underground)
+"pK" = (
+/obj/structure/scrap/cloth,
+/obj/structure/table/rack/shelf,
+/obj/effect/damagedfloor/fire,
+/turf/simulated/floor/tiled/derelict,
+/area/nadezhda/outside/one_star/fo_internal)
 "pL" = (
 /obj/machinery/papershredder,
 /turf/simulated/floor/tiled/derelict,
@@ -1331,6 +1397,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/outside/forest/river_forest_light)
+"qm" = (
+/obj/structure/table/onestar,
+/obj/random/junkfood,
+/obj/effect/damagedfloor/fire,
+/turf/simulated/floor/tiled/derelict/red_white_edges,
+/area/nadezhda/outside/one_star/fo_internal)
 "qn" = (
 /turf/simulated/floor/rock/dark,
 /area/nadezhda/outside/forest/river_forest_light)
@@ -1539,6 +1611,11 @@
 /obj/item/reagent_containers/food/drinks/bottle/pwine,
 /turf/simulated/floor/carpet/gaycarpet,
 /area/nadezhda/outside/forest/river_forest_light)
+"sg" = (
+/obj/structure/flora/small/lavarock1,
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/rock,
+/area/nadezhda/outside/forest/river_forest_underground)
 "sh" = (
 /turf/simulated/floor/asteroid/dirt/mud,
 /area/nadezhda/outside/forest/river_forest_light)
@@ -1577,7 +1654,8 @@
 /turf/simulated/mineral,
 /area/nadezhda/outside/forest/river_forest_underground)
 "sx" = (
-/obj/effect/window_lwall_spawn/smartspawn/onestar,
+/obj/structure/low_wall/onestar,
+/obj/item/material/shard/shrapnel/scrap,
 /turf/simulated/floor/reinforced,
 /area/nadezhda/outside/one_star/fo_internal)
 "sy" = (
@@ -1896,7 +1974,8 @@
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/outside/forest/river_forest_underground)
 "vr" = (
-/obj/random/mob/roomba/any,
+/obj/item/scrap_lump,
+/obj/effect/damagedfloor/fire,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star/fo_internal)
 "vt" = (
@@ -1937,6 +2016,14 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/nadezhda/outside/forest/river_forest_cabin)
+"vL" = (
+/obj/machinery/light/floor,
+/obj/machinery/door/blast/shutters{
+	maxHealth = 15;
+	name = "damaged shutters"
+	},
+/turf/simulated/floor/tiled/derelict/white_small_edges,
+/area/nadezhda/outside/one_star/fo_internal)
 "vM" = (
 /obj/item/reagent_containers/food/snacks/amanita_pie,
 /turf/simulated/floor/rock/grey,
@@ -2001,11 +2088,24 @@
 /obj/random/mob/tahca/low_chance,
 /turf/simulated/floor/asteroid/grass/jungle,
 /area/nadezhda/outside/forest/river_forest_light)
+"wr" = (
+/obj/structure/scrap/cloth,
+/obj/structure/table/rack/shelf,
+/obj/machinery/light/floor,
+/obj/effect/decal/cleanable/ash,
+/obj/effect/damagedfloor/fire,
+/turf/simulated/floor/tiled/derelict,
+/area/nadezhda/outside/one_star/fo_internal)
 "wt" = (
 /obj/item/reagent_containers/glass/beaker/vial/random,
 /obj/structure/flora/small/lavarock2,
 /turf/simulated/floor/asteroid/dirt/mud,
 /area/nadezhda/outside/forest/river_forest_lake)
+"wu" = (
+/obj/effect/window_lwall_spawn/smartspawn/onestar,
+/obj/effect/damagedfloor/fire,
+/turf/simulated/floor/tiled/derelict/red_white_edges,
+/area/nadezhda/outside/one_star/fo_internal)
 "wv" = (
 /obj/item/oddity/common/rusted_sword,
 /turf/simulated/floor/beach/water/shallow,
@@ -2192,6 +2292,7 @@
 "yc" = (
 /obj/structure/flora/small/trailrocka2,
 /obj/structure/scrap/food/large,
+/obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/rock,
 /area/nadezhda/outside/forest/river_forest_underground)
 "yd" = (
@@ -2478,6 +2579,7 @@
 "As" = (
 /obj/structure/table/onestar,
 /obj/structure/scrap/guns,
+/obj/effect/damagedfloor/fire,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star/fo_internal)
 "At" = (
@@ -2551,6 +2653,11 @@
 /obj/item/stack/ore,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest/river_forest_dark)
+"Bf" = (
+/obj/structure/flora/rock/variant2,
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/rock,
+/area/nadezhda/outside/forest/river_forest_underground)
 "Bi" = (
 /obj/item/stack/material/wood,
 /turf/simulated/floor/rock/grey,
@@ -2677,6 +2784,11 @@
 /obj/structure/scrap/food/large,
 /turf/simulated/floor/rock/alt,
 /area/nadezhda/outside/forest/river_forest_dark)
+"Ci" = (
+/obj/effect/damagedfloor/fire,
+/obj/item/scrap_lump,
+/turf/simulated/floor/tiled/derelict/white_small_edges,
+/area/nadezhda/outside/one_star/fo_internal)
 "Ck" = (
 /obj/item/stack/ore/strangerock,
 /turf/simulated/floor/rock/dark,
@@ -2750,6 +2862,11 @@
 	},
 /turf/simulated/floor/asteroid/grass/jungle,
 /area/nadezhda/outside/forest/river_forest_light)
+"CR" = (
+/obj/structure/scrap/food/large,
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/rock,
+/area/nadezhda/outside/forest/river_forest_underground)
 "CU" = (
 /obj/random/junk,
 /turf/simulated/floor/beach/sand,
@@ -3204,7 +3321,6 @@
 /obj/item/gun/projectile/rivet,
 /obj/item/remains,
 /obj/item/ammo_magazine/magnum_40/hv,
-/mob/living/carbon/superior_animal/xenomorph/runner,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star/fo_internal)
 "HC" = (
@@ -3220,8 +3336,11 @@
 /turf/simulated/floor/asteroid/dirt/mud,
 /area/nadezhda/outside/forest/plains_farm)
 "HJ" = (
-/obj/structure/bed/chair/custom/onestar/red,
-/obj/random/mob/roomba/range,
+/obj/item/scrap_lump,
+/obj/item/stack/material/wood,
+/obj/item/stack/material/wood,
+/obj/item/stack/material/wood,
+/obj/effect/damagedfloor/fire,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star/fo_internal)
 "HK" = (
@@ -3378,6 +3497,11 @@
 /obj/item/organ/internal/bone/l_leg,
 /turf/simulated/floor/rock,
 /area/nadezhda/outside/forest/river_forest_underground)
+"JA" = (
+/obj/structure/boulder,
+/obj/structure/boulder,
+/turf/simulated/floor/rock,
+/area/nadezhda/outside/forest/river_forest_underground)
 "JC" = (
 /obj/item/stack/ore,
 /turf/simulated/floor/rock/grey,
@@ -3530,6 +3654,11 @@
 /obj/random/powercell/low_chance,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star/fo_internal)
+"Le" = (
+/obj/structure/bed/chair/custom/onestar/red,
+/obj/effect/damagedfloor/fire,
+/turf/simulated/floor/tiled/derelict/white_small_edges,
+/area/nadezhda/outside/one_star/fo_internal)
 "Lg" = (
 /obj/effect/decal/cleanable/liquid_fuel/flamethrower_fuel,
 /obj/effect/spider/stickyweb,
@@ -3539,6 +3668,12 @@
 /obj/structure/table/onestar,
 /obj/random/pack/tech_loot/onestar,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
+/area/nadezhda/outside/one_star/fo_internal)
+"Ln" = (
+/obj/item/scrap_lump,
+/obj/effect/damagedfloor/fire,
+/obj/effect/damagedfloor/fire,
+/turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star/fo_internal)
 "Ls" = (
 /obj/item/stack/ore/diamond,
@@ -3843,6 +3978,13 @@
 /obj/random/junkfood/onlypizza,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star/fo_internal)
+"NW" = (
+/obj/effect/damagedfloor/fire,
+/obj/item/stack/material/wood,
+/obj/item/stack/material/wood,
+/obj/item/stack/material/wood,
+/turf/simulated/floor/tiled/derelict/white_small_edges,
+/area/nadezhda/outside/one_star/fo_internal)
 "NY" = (
 /obj/item/trash/tastybread,
 /turf/simulated/floor/asteroid/grass/jungle,
@@ -3902,10 +4044,20 @@
 /obj/machinery/light/floor,
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/outside/forest/river_forest_cabin)
+"OH" = (
+/obj/structure/bed/chair/custom/onestar/red,
+/obj/item/material/shard/shrapnel/scrap,
+/turf/simulated/floor/tiled/derelict/red_white_edges,
+/area/nadezhda/outside/one_star/fo_internal)
 "OJ" = (
 /obj/structure/table/marble,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest/river_forest_light)
+"OK" = (
+/obj/structure/table/onestar,
+/obj/effect/damagedfloor/fire,
+/turf/simulated/floor/tiled/derelict,
+/area/nadezhda/outside/one_star/fo_internal)
 "OQ" = (
 /obj/item/oddity/common/old_knife,
 /turf/simulated/floor/rock/grey,
@@ -3945,6 +4097,11 @@
 "Pj" = (
 /turf/simulated/floor/asteroid/dirt/mud,
 /area/nadezhda/outside/forest/river_forest_underground)
+"Pl" = (
+/obj/machinery/light/floor,
+/obj/effect/damagedfloor/fire,
+/turf/simulated/floor/tiled/derelict/white_small_edges,
+/area/nadezhda/outside/one_star/fo_internal)
 "Pm" = (
 /obj/item/stack/ore/glass,
 /turf/simulated/floor/rock/alt,
@@ -4005,6 +4162,11 @@
 /obj/structure/scrap/cloth,
 /obj/structure/table/rack/shelf,
 /turf/simulated/floor/tiled/derelict,
+/area/nadezhda/outside/one_star/fo_internal)
+"PW" = (
+/obj/structure/low_wall/onestar,
+/obj/item/material/shard/shrapnel/scrap,
+/turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star/fo_internal)
 "Qf" = (
 /obj/structure/table/rack/shelf,
@@ -4091,6 +4253,13 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest/river_forest_light)
+"Rn" = (
+/obj/machinery/door/blast/shutters{
+	maxHealth = 15;
+	name = "damaged shutters"
+	},
+/turf/simulated/floor/tiled/derelict/white_big_edges,
+/area/nadezhda/outside/one_star/fo_internal)
 "Ro" = (
 /obj/item/stack/rods/random,
 /turf/simulated/floor/rock,
@@ -4169,6 +4338,10 @@
 /obj/machinery/power/port_gen/pacman/camp,
 /turf/simulated/floor/rock/grey,
 /area/nadezhda/outside/forest/river_forest_dark)
+"Se" = (
+/mob/living/carbon/superior_animal/robot/greyson/custodian,
+/turf/simulated/floor/tiled/derelict/white_big_edges,
+/area/nadezhda/outside/one_star/fo_internal)
 "Sf" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/item/roach_egg,
@@ -4311,7 +4484,7 @@
 /turf/simulated/floor/rock/alt,
 /area/nadezhda/outside/forest/river_forest_dark)
 "TI" = (
-/mob/living/carbon/superior_animal/robot/greyson/roomba/trip,
+/obj/item/scrap_lump,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star/fo_internal)
 "TK" = (
@@ -4390,6 +4563,7 @@
 "Up" = (
 /obj/structure/table/onestar,
 /obj/item/oddity/secdocs,
+/obj/random/junkfood,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star/fo_internal)
 "Ut" = (
@@ -4523,6 +4697,12 @@
 "Vu" = (
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/forest/river_forest_light)
+"Vv" = (
+/obj/effect/damagedfloor/fire,
+/obj/machinery/light_construct/floor,
+/obj/item/material/shard/shrapnel/scrap,
+/turf/simulated/floor/tiled/derelict/white_small_edges,
+/area/nadezhda/outside/one_star/fo_internal)
 "Vw" = (
 /obj/item/roach_egg,
 /obj/random/circuitboard,
@@ -4579,6 +4759,10 @@
 /obj/random/oddity_guns,
 /turf/simulated/floor/rock,
 /area/nadezhda/outside/forest/river_forest_underground)
+"VZ" = (
+/obj/effect/damagedfloor/fire,
+/turf/simulated/floor/tiled/derelict,
+/area/nadezhda/outside/one_star/fo_internal)
 "Wc" = (
 /obj/random/junk/cigbutt,
 /turf/simulated/floor/beach/sand,
@@ -24557,7 +24741,7 @@ bl
 Ij
 MD
 Ij
-Ij
+pb
 fN
 bz
 IP
@@ -24752,20 +24936,20 @@ Ij
 Ij
 Tv
 ca
-Ij
+pb
 kl
 Ak
 bl
 Ij
 MD
-Ij
-vr
+pb
+Ln
 fN
 bz
 IP
 Ij
 nv
-Ij
+pb
 nv
 Ij
 AC
@@ -24953,21 +25137,21 @@ CG
 Ij
 ca
 Mk
-Ij
-pQ
-kl
+pb
+vr
+OK
 Ak
 bl
 aS
 ca
-Ij
-Ij
+pb
+oM
 fN
 bz
 IP
 Ij
 As
-vr
+ee
 As
 Ij
 AC
@@ -25156,20 +25340,20 @@ Ij
 ca
 FT
 Ij
-Ij
+pb
 kl
 Ak
 bl
 Ij
 pN
 Ij
-Ij
+Ci
 fN
 bz
 IP
 Rr
 Ij
-aS
+Pl
 Ij
 Ij
 AC
@@ -25559,7 +25743,7 @@ DM
 Ij
 Dx
 ca
-sH
+TI
 Ij
 MD
 fN
@@ -25768,7 +25952,7 @@ aS
 Ij
 Ij
 ca
-Ij
+pb
 Ij
 fN
 fN
@@ -25965,19 +26149,19 @@ Ij
 XD
 Ij
 Rr
-MD
+hl
 fN
 MD
 MD
-MD
-pQ
+et
+Ci
+pb
 Ij
 Ij
 Ij
 Ij
 Ij
-Ij
-pQ
+bJ
 Ij
 Ij
 Gn
@@ -26169,11 +26353,11 @@ Ij
 Ij
 kl
 sx
-bl
+OH
 Ij
 pN
+pb
 Ij
-sH
 Ij
 Ij
 Ij
@@ -26368,11 +26552,11 @@ Ij
 Ij
 wx
 Dx
-Ij
-ys
+pb
+el
 Ak
 bl
-Ij
+nc
 pN
 Ij
 Ij
@@ -26569,9 +26753,9 @@ kl
 Ij
 KS
 jZ
-ca
-pQ
-kl
+fW
+vr
+OK
 Ak
 bl
 aS
@@ -26582,7 +26766,7 @@ Ij
 ca
 Ij
 Ij
-Ij
+pb
 Ij
 Ij
 Ij
@@ -26772,7 +26956,7 @@ Ij
 Ij
 Ij
 ca
-Ij
+pb
 CG
 Ak
 bl
@@ -26783,9 +26967,9 @@ Ij
 ca
 Ij
 Ij
-Ij
-vr
-Ij
+pb
+ee
+pb
 Ij
 Ij
 MD
@@ -26986,9 +27170,9 @@ Ij
 hH
 PR
 PR
+pK
 PR
-PR
-hH
+wr
 Ij
 MD
 fN
@@ -27189,9 +27373,9 @@ Ij
 Ij
 Ij
 Ij
-Ij
-pQ
-Ij
+pb
+ee
+pb
 MD
 fN
 VG
@@ -27392,7 +27576,7 @@ fN
 Ak
 Ak
 Ak
-Ak
+wu
 Ak
 fN
 fN
@@ -27580,7 +27764,7 @@ Ij
 sH
 Ij
 Ij
-cO
+Ij
 rs
 MD
 MD
@@ -27591,7 +27775,7 @@ Ij
 MD
 Ak
 OC
-Ij
+pb
 Mn
 Mn
 Mn
@@ -27780,7 +27964,7 @@ fN
 GY
 Ij
 fw
-RH
+aF
 yd
 Ij
 MD
@@ -27789,10 +27973,10 @@ MD
 qb
 Du
 MD
-Ij
-MD
-Ak
-fz
+pb
+hl
+PW
+qm
 HJ
 fe
 GH
@@ -27981,7 +28165,7 @@ VG
 fN
 XA
 Ij
-Ij
+pQ
 Ij
 CC
 Ij
@@ -27990,12 +28174,12 @@ BQ
 MD
 XA
 Du
-MD
-pQ
-MD
+VZ
+Ci
+VZ
 Ak
 Vp
-VF
+Le
 RB
 NT
 RB
@@ -28193,12 +28377,12 @@ MD
 XA
 fN
 MD
-Ij
+pb
 MD
 fN
 fz
 Ij
-Ty
+NW
 Ty
 Ty
 Ij
@@ -28392,16 +28576,16 @@ OR
 Ij
 Ij
 aS
-cO
+Ij
 Cu
 MD
 Ij
 MD
 Ij
 Ij
-aS
+Vv
 vr
-Ij
+pb
 Ij
 aS
 Vp
@@ -28602,7 +28786,7 @@ MD
 fN
 fz
 Ij
-Mn
+fn
 Mn
 Mn
 Ij
@@ -28992,9 +29176,9 @@ fN
 GY
 Ij
 If
-RH
+aF
 yd
-Ij
+pQ
 MD
 BQ
 MD
@@ -29192,7 +29376,7 @@ qa
 VG
 fN
 GY
-cO
+Ij
 sH
 Ij
 Ij
@@ -30213,7 +30397,7 @@ MD
 pE
 Ak
 MD
-Ij
+pb
 MD
 Ak
 ZR
@@ -30414,14 +30598,14 @@ pN
 MD
 MD
 Ak
-MD
-pQ
-MD
+VZ
+vr
+VZ
 Ak
 ZR
 Ij
 ZR
-Ij
+pb
 ZR
 Ij
 ZR
@@ -30617,14 +30801,14 @@ MD
 MD
 oi
 Ij
+pb
 Ij
 Ij
 Ij
 Ij
-Ij
-Ij
-pQ
-Ij
+pb
+vr
+pb
 Ij
 Ij
 fN
@@ -30819,13 +31003,13 @@ Ij
 Ij
 qG
 Ij
-Ij
+pb
 Ij
 aS
 Ij
 Ij
 Tc
-Ij
+pb
 Tc
 ca
 aS
@@ -31020,9 +31204,9 @@ MD
 MD
 MD
 oi
-Ij
-pQ
-Ij
+pb
+vr
+pb
 Ij
 Ij
 Ij
@@ -31216,14 +31400,14 @@ fN
 MD
 Ij
 XK
-fW
+tQ
 Ij
 MD
 MD
 MD
 Ak
 MD
-Ij
+pb
 MD
 Ak
 ZR
@@ -32423,7 +32607,7 @@ Ij
 Ij
 Ij
 Ij
-pQ
+TI
 ca
 Ij
 Ij
@@ -32630,7 +32814,7 @@ Ij
 Ij
 Ij
 Ij
-pb
+TI
 Ij
 Ij
 Ij
@@ -33041,7 +33225,7 @@ oi
 bl
 cM
 Ij
-pb
+TI
 Ij
 Ak
 Lm
@@ -33446,7 +33630,7 @@ oi
 cM
 Ij
 Ij
-Ij
+pb
 Ak
 oi
 oi
@@ -33635,7 +33819,7 @@ Ak
 Ak
 cM
 Ij
-Ij
+pb
 Ij
 Ak
 Ak
@@ -33647,8 +33831,8 @@ Ak
 Ak
 cM
 Ij
-Ij
-TI
+pb
+vr
 Ak
 Ak
 Ak
@@ -33825,20 +34009,20 @@ qa
 VG
 fN
 Ij
+Ij
+ca
+Ak
+oi
+oi
+oi
+Ak
+Yr
+qD
+oi
+cM
 pb
-ca
-Ak
-oi
-oi
-oi
-Ak
-Yr
-qD
-oi
-cM
-Ij
-TI
-Ij
+vr
+pb
 Ak
 oi
 oi
@@ -33850,7 +34034,7 @@ oi
 cM
 ca
 Ij
-Ij
+pb
 Ak
 oi
 oi
@@ -34039,7 +34223,7 @@ fL
 oi
 Ij
 Ij
-Ij
+fi
 ca
 oi
 oi
@@ -34240,9 +34424,9 @@ Lm
 oi
 oi
 cM
-Ij
 pb
-Ij
+vr
+pb
 Ak
 qD
 Lm
@@ -34443,7 +34627,7 @@ Ak
 Ak
 cM
 Oq
-Ij
+pb
 Ij
 Ak
 Ak
@@ -34645,7 +34829,7 @@ oi
 oi
 cM
 Ij
-pQ
+Ij
 Ij
 Ak
 Yr
@@ -34760,7 +34944,7 @@ qa
 kv
 NS
 Et
-Pj
+BU
 qa
 qa
 qa
@@ -34961,8 +35145,8 @@ qa
 qa
 qa
 Pj
-Pj
-Pj
+BU
+BU
 qa
 qa
 qa
@@ -35049,7 +35233,7 @@ fz
 oi
 cM
 Ij
-Ij
+TI
 Ij
 Ak
 oi
@@ -35162,8 +35346,8 @@ qa
 qa
 qa
 qa
-Pj
-Pj
+BU
+BU
 qa
 qa
 qa
@@ -35263,7 +35447,7 @@ Ak
 Ak
 cM
 Ij
-Ij
+pb
 Ij
 Ak
 Ak
@@ -35365,9 +35549,9 @@ qa
 qa
 qa
 qa
-yp
-yp
-yp
+BU
+BU
+Te
 yp
 qa
 qa
@@ -35453,7 +35637,7 @@ Yr
 oi
 cM
 Ij
-pQ
+Ij
 Ij
 Ak
 oi
@@ -35464,9 +35648,9 @@ Yr
 Yr
 oi
 cM
-Ij
-ee
-Ij
+pb
+vr
+pb
 Ak
 oi
 oi
@@ -35567,7 +35751,7 @@ qa
 qa
 qa
 yp
-yp
+BU
 tA
 tA
 yp
@@ -35667,7 +35851,7 @@ aC
 oi
 Ij
 Ij
-Ij
+pb
 Ij
 oi
 oi
@@ -36447,7 +36631,7 @@ fN
 bX
 ZT
 Tn
-ZT
+Se
 ld
 fN
 Ij
@@ -37055,8 +37239,8 @@ TO
 aS
 sj
 ZT
-ZT
-ca
+Rn
+fW
 ca
 Ij
 Ak
@@ -37258,32 +37442,32 @@ Ij
 sj
 ZT
 fN
-ee
-ca
-Ij
-oi
-oi
-aC
-Lm
-Ak
-Lm
-iC
-oi
-Ij
-Ij
-Ij
-Ij
-oi
-oi
-aC
-Lm
-Ak
-Lm
-iC
-oi
-Ij
-Ij
 vr
+jS
+Ij
+oi
+oi
+aC
+Lm
+Ak
+Lm
+iC
+oi
+Ij
+Ij
+Ij
+Ij
+oi
+oi
+aC
+Lm
+Ak
+Lm
+iC
+oi
+Ij
+Ij
+Ij
 Ij
 oi
 oi
@@ -37460,9 +37644,9 @@ Vr
 Ij
 ld
 fN
-ca
+jS
 vr
-Ij
+pb
 Ak
 fz
 Yr
@@ -37473,7 +37657,7 @@ oi
 oi
 cM
 Ij
-pb
+Ij
 Ij
 Ak
 fz
@@ -37659,11 +37843,11 @@ fN
 lG
 ZT
 RF
-ZT
+Se
 ld
 fN
 ca
-Ij
+pb
 Ij
 Ak
 Ak
@@ -37809,7 +37993,7 @@ BU
 Ka
 yp
 yp
-yp
+Te
 sC
 sC
 sC
@@ -38010,8 +38194,8 @@ id
 id
 Te
 yp
-yp
-yp
+Te
+Te
 sC
 sC
 sC
@@ -38079,7 +38263,7 @@ iC
 oi
 Ij
 Ij
-vr
+Ij
 Ij
 oi
 oi
@@ -38090,7 +38274,7 @@ qD
 iC
 oi
 Ij
-Ij
+pb
 Ij
 Ij
 oi
@@ -38212,13 +38396,13 @@ id
 id
 BU
 yp
-yp
-yp
+Te
+Te
 sC
 sC
 xK
-yp
-yp
+Te
+Te
 FE
 FE
 uh
@@ -38292,8 +38476,8 @@ Yr
 Lm
 oi
 cM
-pQ
-Ij
+vr
+pb
 Ij
 Ak
 oi
@@ -38413,15 +38597,15 @@ tS
 id
 id
 BU
-yp
-yp
-yp
-yp
-yp
-yp
-yp
-yp
-FE
+Te
+Te
+JA
+fm
+fm
+fm
+fm
+Te
+ZH
 FE
 uh
 JE
@@ -38494,7 +38678,7 @@ Ak
 Ak
 Ak
 cM
-Ij
+pb
 Ij
 Ij
 Ak
@@ -38616,14 +38800,14 @@ id
 id
 BU
 Jj
-yp
-yp
+Te
+Te
 xK
-yp
-wg
-yp
-yp
-FE
+fm
+Vx
+fm
+fm
+ZH
 Dy
 uh
 uh
@@ -38819,13 +39003,13 @@ BU
 tA
 yp
 yp
-yp
-yp
-yp
-yp
-yp
-yp
-FE
+Te
+fm
+fm
+fm
+fm
+Te
+ZH
 FE
 uh
 FE
@@ -39021,12 +39205,12 @@ BU
 yp
 yp
 yp
-yp
-yp
-yp
-yp
-yp
-wg
+Te
+fm
+fm
+fm
+Te
+sg
 FE
 FE
 FE
@@ -39291,7 +39475,7 @@ Ak
 Ak
 cM
 ca
-Ij
+pb
 Ij
 Ak
 Ak
@@ -39481,7 +39665,7 @@ qa
 VG
 fN
 Ij
-pb
+TI
 Ij
 Ak
 fz
@@ -39492,7 +39676,7 @@ Yr
 oi
 oi
 cM
-Ij
+pb
 vr
 pb
 Ak
@@ -39505,7 +39689,7 @@ oi
 oi
 cM
 Ij
-Ij
+pb
 Ij
 Ak
 fz
@@ -39624,7 +39808,7 @@ id
 id
 BU
 BU
-yp
+Te
 qa
 qa
 qa
@@ -39695,7 +39879,7 @@ aC
 oi
 Ij
 Ij
-Ij
+pb
 Ij
 oi
 oi
@@ -39706,9 +39890,9 @@ Lm
 aC
 oi
 Ij
-ca
-pQ
-Ij
+fW
+vr
+pb
 oi
 oi
 qG
@@ -39909,7 +40093,7 @@ qD
 oi
 cM
 Ij
-Ij
+pb
 Ij
 Ak
 qb
@@ -40099,8 +40283,8 @@ Ak
 Ak
 cM
 Ij
-ee
 Ij
+TI
 Ak
 Ak
 Ak
@@ -40464,9 +40648,9 @@ Pj
 NS
 NS
 Pj
-yp
-FE
-FE
+Te
+ZH
+ZH
 fS
 sC
 sC
@@ -40499,7 +40683,7 @@ Ij
 Ij
 Ij
 Ij
-pb
+TI
 Ij
 Ij
 Ij
@@ -40665,11 +40849,11 @@ yp
 Pj
 NS
 NS
-yp
-yp
+Te
+eY
 Np
-FE
-fS
+ZH
+cO
 sC
 sC
 sC
@@ -40705,7 +40889,7 @@ fN
 fN
 fN
 fN
-aS
+vL
 fN
 fN
 fN
@@ -40866,12 +41050,12 @@ yp
 yp
 yp
 yp
-Pj
-yp
+Xh
+Te
 fm
 Np
-FE
-fS
+Np
+cO
 sC
 sC
 sC
@@ -40907,7 +41091,7 @@ fN
 fN
 fN
 fN
-Ij
+Cu
 fN
 fN
 fN
@@ -41067,11 +41251,11 @@ yp
 yp
 dF
 yp
-yp
-yp
+Te
+fX
 fm
 fm
-yp
+Te
 yc
 sC
 sC
@@ -41270,11 +41454,11 @@ xX
 xX
 xX
 sC
-DW
-yp
-yp
-yp
-xX
+Bf
+Te
+Te
+Te
+CR
 sC
 sC
 sC
@@ -41472,8 +41656,8 @@ xX
 xX
 sC
 sC
-sC
-xX
+iw
+CR
 ta
 yp
 xX

--- a/maps/_DeepForest/map/_River_To_Colony.dmm
+++ b/maps/_DeepForest/map/_River_To_Colony.dmm
@@ -131,6 +131,10 @@
 "bY" = (
 /turf/simulated/floor/rock/grey,
 /area/colony/exposedsun/crashed_shop/bottom_floor)
+"cb" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/mineral,
+/area/colony/exposedsun/crashed_shop/bottom_floor)
 "cc" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -697,6 +701,7 @@
 /area/colony/exposedsun/crashed_shop)
 "lf" = (
 /mob/living/simple_animal/hostile/hell_pig/wendigo,
+/obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/rock,
 /area/colony/exposedsun/crashed_shop/bottom_floor)
 "lp" = (
@@ -1426,6 +1431,10 @@
 /obj/random/voidsuit/low_chance,
 /turf/simulated/floor/wood_old,
 /area/colony/exposedsun/crashed_shop/workshop)
+"xr" = (
+/obj/structure/invislight,
+/turf/simulated/floor/asteroid/dirt,
+/area/colony/exposedsun/crashed_shop/bottom_floor)
 "xy" = (
 /obj/structure/railing{
 	dir = 8
@@ -2336,6 +2345,10 @@
 "Lr" = (
 /turf/simulated/wall/wood_old,
 /area/colony/exposedsun/crashed_shop/workshop)
+"Lu" = (
+/obj/structure/invislight,
+/turf/simulated/floor/rock,
+/area/colony/exposedsun/crashed_shop/bottom_floor)
 "LC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/pack/rare,
@@ -2643,9 +2656,8 @@
 /turf/simulated/floor/plating/under,
 /area/colony/exposedsun/crashed_shop/bottom_floor)
 "Pk" = (
-/obj/item/remains,
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/asteroid/dirt/dark,
+/turf/simulated/floor/rock,
 /area/colony/exposedsun/crashed_shop/bottom_floor)
 "Pl" = (
 /obj/structure/sign/departmentold/janitorial{
@@ -3254,6 +3266,12 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/colony/exposedsun/crashed_shop)
+"Zp" = (
+/obj/item/remains,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/rock,
+/area/colony/exposedsun/crashed_shop/bottom_floor)
 "Zr" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/rig_module/low_chance,
@@ -4102,8 +4120,8 @@ UX
 UX
 UX
 KU
-uy
-UK
+mm
+UX
 UK
 UK
 Fe
@@ -4184,8 +4202,8 @@ UX
 UX
 UX
 uy
-uy
-uy
+fc
+UX
 gz
 fc
 fc
@@ -4266,13 +4284,13 @@ uy
 uy
 Ob
 uy
-uy
-uy
+fc
+xr
 fc
 fc
 UK
 fc
-UK
+fc
 UK
 UX
 UX
@@ -4348,12 +4366,12 @@ uy
 uy
 uy
 uy
-Pk
-uy
+Ss
+UX
 fc
 UK
 ys
-fc
+UK
 Fe
 UK
 UK
@@ -4430,8 +4448,8 @@ Lj
 mm
 uy
 uy
-uy
-uy
+fc
+xr
 fc
 UK
 UX
@@ -4512,8 +4530,8 @@ Lj
 uy
 wZ
 Ob
-uy
-uy
+UX
+UX
 fc
 hg
 UX
@@ -4595,9 +4613,9 @@ uy
 uy
 uy
 uy
-uy
-Ss
-UK
+UX
+UX
+UX
 UX
 UX
 UK
@@ -5251,7 +5269,7 @@ Uw
 uy
 uy
 uy
-uy
+mm
 uy
 fc
 fc
@@ -7548,13 +7566,13 @@ aQ
 Yw
 Yw
 Yw
-lf
+Yw
 KK
 aQ
 Yw
 Yw
-Yw
-Yw
+Zp
+MC
 lP
 lP
 wv
@@ -7635,11 +7653,11 @@ Yw
 Yw
 Yw
 Yw
-Yw
+Zp
 Yw
 Yw
 lP
-wv
+lP
 wv
 wv
 wv
@@ -7720,10 +7738,10 @@ Yw
 Yw
 Yw
 Ta
+Lu
+Yw
 lP
-wv
-wv
-wv
+lP
 wv
 wv
 wv
@@ -7802,10 +7820,10 @@ Yw
 Yw
 Yw
 Yw
+Lu
+Yw
+Yw
 lP
-wv
-wv
-wv
 wv
 wv
 wv
@@ -7883,12 +7901,12 @@ Yw
 Yw
 Yw
 Yw
+MC
+lP
+Yw
+Yw
 Yw
 lP
-wv
-wv
-wv
-wv
 wv
 wv
 "}
@@ -7966,11 +7984,11 @@ Yw
 Yw
 Yw
 lP
+cb
 lP
-wv
-wv
-wv
-wv
+Pk
+Yw
+lP
 wv
 wv
 "}
@@ -8048,11 +8066,11 @@ Yw
 Yw
 Yw
 lP
-wv
-wv
-wv
-wv
-wv
+lP
+lP
+Yw
+MC
+lP
 wv
 wv
 "}
@@ -8130,11 +8148,11 @@ Yw
 lP
 lP
 lP
-wv
-wv
-wv
-wv
-wv
+lP
+Ta
+MC
+Yw
+lP
 wv
 wv
 "}
@@ -8212,11 +8230,11 @@ UX
 UX
 UX
 UX
-wv
-wv
-wv
-wv
-wv
+lP
+Yw
+Yw
+Yw
+lP
 wv
 wv
 "}
@@ -8294,11 +8312,11 @@ UX
 UX
 UX
 UX
-wv
-wv
-wv
-wv
-wv
+lP
+MC
+MC
+lP
+lP
 wv
 wv
 "}
@@ -8376,11 +8394,11 @@ UX
 UX
 UX
 UX
-wv
-wv
-wv
-wv
-wv
+lP
+Yw
+MC
+lP
+lP
 wv
 wv
 "}
@@ -8458,11 +8476,11 @@ UX
 UX
 UX
 UX
-wv
-wv
-wv
-wv
-wv
+lP
+MC
+Pk
+MC
+lP
 wv
 wv
 "}
@@ -8540,11 +8558,11 @@ UX
 UX
 UX
 UX
-wv
-wv
-wv
-wv
-wv
+lP
+Pk
+MC
+Ta
+lP
 wv
 wv
 "}
@@ -8622,11 +8640,11 @@ UX
 UX
 UX
 UX
-wv
-wv
-wv
-wv
-wv
+lP
+Pk
+lf
+lP
+lP
 wv
 wv
 "}
@@ -8704,11 +8722,11 @@ UX
 UX
 UX
 UX
-wv
-wv
-wv
-wv
-wv
+lP
+lP
+Pk
+lP
+lP
 wv
 wv
 "}
@@ -8786,10 +8804,10 @@ UX
 UX
 UX
 UX
-wv
-wv
-wv
-wv
+lP
+lP
+lP
+lP
 wv
 wv
 wv
@@ -8868,10 +8886,10 @@ UX
 UX
 UX
 UX
-wv
-wv
-wv
-wv
+lP
+lP
+lP
+lP
 wv
 wv
 wv
@@ -8950,10 +8968,10 @@ UX
 UX
 UX
 UX
-wv
-wv
-wv
-wv
+lP
+lP
+lP
+lP
 wv
 wv
 wv


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Makes it so that mobs sleep at random intervals to prevent them from causing a severe bottleneck on processing power when they all decide to sleep at once and when they all decide to scan their surroundings at once. By having this set between random intervals each time they sleep, it reduces the potential for lag spikes and allows headway for other mobs to be processed at once. This also allows mobs to remain active for longer durations as well and can also make them deactivate sooner, giving a sort of 'realistic' touch to it when mobs start to die down individually from a sort of adrenaline rush in a way, instead of every mob acting like a hivemind and just plopping down immediately. This PR also prevents mobs from waking themselves up by opening doors and only makes it so that players can open them. Mobs can and will still in-fight at round start, but I have reduced it as much as I possibly can by editing the map in a select few locations, replacing mobs spawns and changing where they spawn. Mobs also react much faster than previously, where you could typically walk up to a mob before their AI updates. Now it seems that their AI updates the moment they see you, at least in my local testing. This absolutely needs more attention however and for more people to look into this. Also. Insects, like roaches and spiders, no longer breathe atmos. I felt like that was indirectly stressing Atmos here, which we barely utilize to begin with. They can still die due to pressure however. 
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
tweak: Mobs now sleep at random intervals to reduce bottleneck on the server.
tweak: Mobs can no longer wake themselves up by opening doors, causing them to stay awake forever.
tweak: Mobs are alerted at longer ranges by players however to compensate. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
