### PR TITLE
Fixes Klutz Mishaps Permanently Jamming Guns

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -620,6 +620,7 @@ For the sake of consistency, I suggest always rounding up on even values when ap
 				user.drop_item()
 		else
 			handle_click_empty(user)
+		currently_firing = FALSE	//Add this here or else people who have clumsy will permanently break guns and prevent them from firing if they fuck up with it.
 		return FALSE
 
 	currently_firing = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

Addresses the bug listed in Issue #66. 

## About The Pull Request
Added a reset to a gun's currently_firing variable just before the klutz fuckup return, allowing guns that are mishapped by klutzes to be fired again without having any other impact on the way that guns work. 


## Changelog
fix: Klutz mishaps no longer permanently break guns. 

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
