### PR TITLE
Remove Armor Divisors and replace with Flat Damage Penetration, tweaked projectile damage as a whole

### DIFF
--- a/code/__DEFINES/weapons.dm
+++ b/code/__DEFINES/weapons.dm
@@ -12,14 +12,14 @@
 #define WEAPON_FORCE_GODLIKE		88 // currently only used by the energy axe, which can only be obtained via admin verbs
 
 //Armor Penetration: Ignores a certain amount of armor for the purposes of inflicting damage.
-#define ARMOR_PEN_GRAZING			1.2
-#define ARMOR_PEN_SHALLOW			1.4
-#define ARMOR_PEN_MODERATE			1.6
-#define ARMOR_PEN_DEEP				1.8
-#define ARMOR_PEN_HALF				2
-#define ARMOR_PEN_EXTREME			2.5
-#define ARMOR_PEN_MASSIVE			3
-#define ARMOR_PEN_MAX				10
+#define ARMOR_PEN_GRAZING			1
+#define ARMOR_PEN_SHALLOW			2
+#define ARMOR_PEN_MODERATE			4
+#define ARMOR_PEN_DEEP				6
+#define ARMOR_PEN_DEADLY			8
+#define ARMOR_PEN_EXTREME			12
+#define ARMOR_PEN_MASSIVE			16
+#define ARMOR_PEN_MAX				20
 
 //Wounding Multiplier: Increases damage taken, applied after armor.
 #define WOUNDING_HARMLESS			0.25

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -285,7 +285,7 @@ avoid code duplication. This includes items that may sometimes act as a standard
 			if(!i==0)
 				T = get_step(T, get_dir(user, A))
 				force = force * 0.8 //20% less damage each step forwards
-				armor_divisor -= 0.2 //Lower AD a little, per tile
+				armor_penetration -= 0.2 //Lower AD a little, per tile
 			//else
 				//message_admins("0th tile bypassed")
 

--- a/code/datums/stat_modifiers/mob_modifiers.dm
+++ b/code/datums/stat_modifiers/mob_modifiers.dm
@@ -21,9 +21,9 @@
 	var/inherent_projectile_increment_adjustment
 
 	/// Any projectiles fired by the holder will have their armor penetration increased by this much, added after the mult
-	var/projectile_armor_divisor_adjustment
+	var/projectile_armor_penetration_adjustment
 	/// Any projectiles fired by the holder will have their armor penetration multiplied by this much, added first
-	var/projectile_armor_divisor_mult_increment
+	var/projectile_armor_penetration_mult_increment
 
 	/// Inverted, lower = higher speed
 	var/projectile_speed_increment_adjustment
@@ -66,10 +66,10 @@
 			for (var/entry in projectile_damage_mult)
 				livingholder.projectile_damage_mult[entry] = ZERO_OR_MORE((livingholder.projectile_damage_mult[entry] - projectile_damage_mult[entry]))
 
-		if (projectile_armor_divisor_adjustment)
-			livingholder.projectile_armor_divisor_adjustment = ZERO_OR_MORE((livingholder.projectile_armor_divisor_adjustment - projectile_armor_divisor_adjustment))
-		if (projectile_armor_divisor_mult_increment)
-			livingholder.projectile_armor_divisor_mult = ZERO_OR_MORE((livingholder.projectile_armor_divisor_mult - projectile_armor_divisor_mult_increment))
+		if (projectile_armor_penetration_adjustment)
+			livingholder.projectile_armor_penetration_adjustment = ZERO_OR_MORE((livingholder.projectile_armor_penetration_adjustment - projectile_armor_penetration_adjustment))
+		if (projectile_armor_penetration_mult_increment)
+			livingholder.projectile_armor_penetration_mult = ZERO_OR_MORE((livingholder.projectile_armor_penetration_mult - projectile_armor_penetration_mult_increment))
 
 		if (projectile_speed_increment_adjustment)
 			livingholder.projectile_speed_increment = ZERO_OR_MORE((livingholder.projectile_speed_increment - projectile_speed_increment_adjustment))
@@ -110,10 +110,10 @@
 			for (var/entry in projectile_damage_mult)
 				livingtarget.projectile_damage_mult[entry] = ZERO_OR_MORE((livingtarget.projectile_damage_mult[entry] + projectile_damage_mult[entry]))
 
-		if (projectile_armor_divisor_adjustment)
-			livingtarget.projectile_armor_divisor_adjustment = ZERO_OR_MORE((livingtarget.projectile_armor_divisor_adjustment + projectile_armor_divisor_adjustment))
-		if (projectile_armor_divisor_mult_increment)
-			livingtarget.projectile_armor_divisor_mult = ZERO_OR_MORE((livingtarget.projectile_armor_divisor_mult + projectile_armor_divisor_mult_increment))
+		if (projectile_armor_penetration_adjustment)
+			livingtarget.projectile_armor_penetration_adjustment = ZERO_OR_MORE((livingtarget.projectile_armor_penetration_adjustment + projectile_armor_penetration_adjustment))
+		if (projectile_armor_penetration_mult_increment)
+			livingtarget.projectile_armor_penetration_mult = ZERO_OR_MORE((livingtarget.projectile_armor_penetration_mult + projectile_armor_penetration_mult_increment))
 
 		if (projectile_speed_increment_adjustment)
 			livingtarget.projectile_speed_increment = ZERO_OR_MORE((livingtarget.projectile_speed_increment + projectile_speed_increment_adjustment))

--- a/code/datums/stat_modifiers/modifiers/mob/superior/ranged/ranged_modifiers.dm
+++ b/code/datums/stat_modifiers/modifiers/mob/superior/ranged/ranged_modifiers.dm
@@ -1,7 +1,7 @@
 /datum/stat_modifier/mob/living/carbon/superior_animal/deadeye
 
 	inherent_projectile_mult_increment = 1 //a little more dps, but more easily avoided
-	projectile_armor_divisor_mult_increment = 1.25
+	projectile_armor_penetration_mult_increment = 1.25
 
 	delay_for_range_mult = 1.4
 	delay_for_rapid_range_mult = 1.4
@@ -34,7 +34,7 @@
 	rapid_fire_shooting_amount_mult = 2 //pretty noticable damage increase
 	delay_for_rapid_range_mult = 0.5 //half the delay
 
-	projectile_armor_divisor_mult_increment = -0.5 //significantly worse armor penetration because they're just shooting whatever part of you they can
+	projectile_armor_penetration_mult_increment = -0.5 //significantly worse armor penetration because they're just shooting whatever part of you they can
 
 	inherent_projectile_mult_increment = -0.3 // but still with higher DPS because theyre shooting you twice as much for 70% damage
 

--- a/code/datums/stat_modifiers/modifiers/mob/superior/roach_modifiers.dm
+++ b/code/datums/stat_modifiers/modifiers/mob/superior/roach_modifiers.dm
@@ -7,7 +7,7 @@
 	agony = 15 //Rubbers deal way less to us!
 	)
 
-	armor_divisor_increment = 1.5
+	armor_penetration_increment = 1.5
 
 	stattags = DEFENSE_STATTAG | MELEE_STATTAG
 
@@ -23,7 +23,7 @@
 	)
 
 	flash_resistances_increment = 2
-	armor_divisor_increment = 1.15
+	armor_penetration_increment = 1.15
 
 	stattags = DEFENSE_STATTAG
 

--- a/code/datums/stat_modifiers/modifiers/mob/superior/special/special_modifiers.dm
+++ b/code/datums/stat_modifiers/modifiers/mob/superior/special/special_modifiers.dm
@@ -40,9 +40,9 @@
 
 	move_to_delay_increment = -1.3 // fast
 
-	projectile_armor_divisor_mult_increment = 0.5
-	armor_divisor_mult = 1.5
-	armor_divisor_zeroth = 0.1
+	projectile_armor_penetration_mult_increment = 0.5
+	armor_penetration_mult = 1.5
+	armor_penetration_zeroth = 0.1
 
 	melee_damage_lower_mult = 1.5
 	melee_damage_upper_mult = 1.5

--- a/code/datums/stat_modifiers/modifiers/mob/superior/spider_modifiers.dm
+++ b/code/datums/stat_modifiers/modifiers/mob/superior/spider_modifiers.dm
@@ -5,7 +5,7 @@
 	)
 
 	flash_resistances_increment = 2
-	armor_divisor_increment = 1.25
+	armor_penetration_increment = 1.25
 
 	prefix = "Lustrous"
 
@@ -22,7 +22,7 @@
 		agony = 7
 	)
 
-	armor_divisor_increment = 1.1
+	armor_penetration_increment = 1.1
 	flash_resistances_increment = 1
 	maxHealth_increment = 20
 

--- a/code/datums/stat_modifiers/modifiers/mob/superior/superior_modifiers.dm
+++ b/code/datums/stat_modifiers/modifiers/mob/superior/superior_modifiers.dm
@@ -28,12 +28,12 @@
 	melee_damage_lower_increment = 2
 	melee_damage_upper_increment = 2
 	maxHealth_increment = 5
-	armor_divisor_increment = 1.25
+	armor_penetration_increment = 1.25
 
 	stattags = DEFENSE_STATTAG | MELEE_STATTAG
 
 	inherent_projectile_mult_increment = 0.1
-	projectile_armor_divisor_adjustment = 2
+	projectile_armor_penetration_adjustment = 2
 
 	description = "This one is noticably muscular. It looks like it might hit harder than others."
 

--- a/code/datums/stat_modifiers/modifiers/mob/superior/xeno_modifers.dm
+++ b/code/datums/stat_modifiers/modifiers/mob/superior/xeno_modifers.dm
@@ -25,7 +25,7 @@
 	melee_damage_lower_increment = 5
 	melee_damage_upper_increment = 5
 	maxHealth_increment = 25
-	armor_divisor_increment = 1.25
+	armor_penetration_increment = 1.25
 
 	description = "This one is noticably tougher with sharp claws. It looks like it might hit harder than others."
 

--- a/code/datums/stat_modifiers/superior_modifier_defines.dm
+++ b/code/datums/stat_modifiers/superior_modifier_defines.dm
@@ -24,9 +24,9 @@
 	var/flash_resistances_mult
 	var/flash_resistances_zeroth = 0.5
 
-	var/armor_divisor_increment
-	var/armor_divisor_mult
-	var/armor_divisor_zeroth = 1
+	var/armor_penetration_increment
+	var/armor_penetration_mult
+	var/armor_penetration_zeroth = 1
 
 	var/rapid_fire_shooting_amount_increment
 	var/rapid_fire_shooting_amount_mult
@@ -78,10 +78,10 @@
 		if (flash_resistances_mult)
 			superior_holder.flash_resistances = ZERO_OR_MORE(round(superior_holder.flash_resistances / flash_resistances_mult))
 
-		if (armor_divisor_increment)
-			superior_holder.armor_divisor = ZERO_OR_MORE(superior_holder.armor_divisor - armor_divisor_increment)
-		if (armor_divisor_mult)
-			superior_holder.armor_divisor = ZERO_OR_MORE(superior_holder.armor_divisor / armor_divisor_mult)
+		if (armor_penetration_increment)
+			superior_holder.armor_penetration = ZERO_OR_MORE(superior_holder.armor_penetration - armor_penetration_increment)
+		if (armor_penetration_mult)
+			superior_holder.armor_penetration = ZERO_OR_MORE(superior_holder.armor_penetration / armor_penetration_mult)
 
 		if (fire_delay_increment)
 			superior_holder.fire_delay = ZERO_OR_MORE(superior_holder.fire_delay - fire_delay_increment)
@@ -153,10 +153,10 @@
 		if (flash_resistances_increment)
 			superior_target.flash_resistances = ZERO_OR_MORE(superior_target.flash_resistances + flash_resistances_increment)
 
-		if (armor_divisor_mult)
-			superior_target.armor_divisor = (SAFEMULT(superior_target.armor_divisor, armor_divisor_mult, armor_divisor_zeroth))
-		if (armor_divisor_increment)
-			superior_target.armor_divisor = (superior_target.armor_divisor + armor_divisor_increment)
+		if (armor_penetration_mult)
+			superior_target.armor_penetration = (SAFEMULT(superior_target.armor_penetration, armor_penetration_mult, armor_penetration_zeroth))
+		if (armor_penetration_increment)
+			superior_target.armor_penetration = (superior_target.armor_penetration + armor_penetration_increment)
 
 		if (fire_delay_mult)
 			superior_target.fire_delay_initial = ZERO_OR_MORE(round(SAFEMULT(superior_target.fire_delay_initial, fire_delay_mult, fire_delay_zeroth)))

--- a/code/game/mecha/equipment/tools/mining_tools.dm
+++ b/code/game/mecha/equipment/tools/mining_tools.dm
@@ -12,7 +12,7 @@
 	energy_drain = 10
 	price_tag = 150
 	force = 30
-	armor_divisor = ARMOR_PEN_DEEP
+	armor_penetration = ARMOR_PEN_DEEP
 	structure_damage_factor = STRUCTURE_DAMAGE_HEAVY
 	tool_qualities = list(QUALITY_DIGGING = 60)
 	required_type = list(/obj/mecha/working, /obj/mecha/combat, /obj/mecha/medical)

--- a/code/game/mecha/equipment/tools/work_tools.dm
+++ b/code/game/mecha/equipment/tools/work_tools.dm
@@ -19,7 +19,7 @@
 	energy_drain = 10
 	tool_qualities = list(QUALITY_CLAMPING = 5,  QUALITY_HAMMERING = 30, QUALITY_PRYING = 30, QUALITY_BOLT_TURNING = 20, QUALITY_EXCAVATION = 20, QUALITY_SHOVELING = 30) // This is a literal industrial clamp
 	force = 20
-	armor_divisor = ARMOR_PEN_SHALLOW
+	armor_penetration = ARMOR_PEN_SHALLOW
 	var/obj/mecha/cargo_holder
 	var/can_load_living = FALSE
 
@@ -83,7 +83,7 @@
 	name = "\improper KILL CLAMP"
 	energy_drain = 0
 	force = 90 //Lmao, the mech sword deals 60
-	armor_divisor = ARMOR_PEN_EXTREME //This thing is hilarious, I'm just adding to it
+	armor_penetration = ARMOR_PEN_EXTREME //This thing is hilarious, I'm just adding to it
 	can_load_living = TRUE
 
 /obj/item/mecha_parts/mecha_equipment/tool/extinguisher

--- a/code/game/mecha/equipment/weapons/melee.dm
+++ b/code/game/mecha/equipment/weapons/melee.dm
@@ -17,7 +17,7 @@
 	sharp = TRUE
 	edge = TRUE
 	tool_qualities = list(QUALITY_CUTTING = 35, QUALITY_SAWING = 20) // It's a literal mech sized blade
-	armor_divisor = ARMOR_PEN_DEEP
+	armor_penetration = ARMOR_PEN_DEEP
 	structure_damage_factor = STRUCTURE_DAMAGE_HEAVY
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	var/icon/melee_overlay
@@ -41,7 +41,7 @@
 	tool_qualities = list(QUALITY_CUTTING = 30,  QUALITY_WIRE_CUTTING = 20) //Same as E-cutlasses
 	origin_tech = list(TECH_MAGNET = 5, TECH_POWER = 6, TECH_COMBAT = 3) //Same as E-cutlasses
 	matter = list(MATERIAL_STEEL = 15, MATERIAL_SILVER = 1, MATERIAL_GOLD = 1) //WAY LESS then normal E-cutlasses do to the only being 5 more damage
-	armor_divisor = ARMOR_PEN_DEEP
+	armor_penetration = ARMOR_PEN_DEEP
 	structure_damage_factor = STRUCTURE_DAMAGE_HEAVY
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	var/icon/melee_overlay

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -688,7 +688,7 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 /obj/item/proc/refresh_upgrades()
 	damtype = initial(damtype)
 	force = initial(force)
-	armor_divisor = initial(armor_divisor)
+	armor_penetration = initial(armor_penetration)
 	item_flags = initial(item_flags)
 	name = initial(name)
 	max_upgrades = initial(max_upgrades)
@@ -750,7 +750,7 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 /obj/item/proc/alt_mode_activeate_two()
 	damtype = alt_mode_damagetype
 	force = force *= alt_mode_lossrate
-	armor_divisor= armor_divisor *= alt_mode_lossrate
+	armor_penetration= armor_penetration *= alt_mode_lossrate
 	attack_verb = LAZYCOPY(alt_mode_verbs)
 	sharp = alt_mode_sharp
 	flags |= NOBLOODY

--- a/code/game/objects/items/devices/organ_module/active/armblades.dm
+++ b/code/game/objects/items/devices/organ_module/active/armblades.dm
@@ -13,7 +13,7 @@
 	throwforce = WEAPON_FORCE_WEAK
 	w_class = ITEM_SIZE_SMALL
 	attack_verb = list("stabbed", "chopped", "cut")
-	armor_divisor = ARMOR_PEN_MODERATE
+	armor_penetration = ARMOR_PEN_MODERATE
 	tool_qualities = list(QUALITY_CUTTING = 20)
 
 /obj/item/organ_module/active/simple/proc/get_scanner_name()
@@ -97,7 +97,7 @@
 	worksound = WORKSOUND_HARD_SLASH
 	force = WEAPON_FORCE_ROBUST
 	throwforce = WEAPON_FORCE_WEAK
-	armor_divisor = ARMOR_PEN_MODERATE
+	armor_penetration = ARMOR_PEN_MODERATE
 	w_class = ITEM_SIZE_SMALL
 	attack_verb = list("stabbed", "chopped", "cut", "sliced", "reaped")
 	tool_qualities = list(QUALITY_CUTTING = 30)
@@ -123,7 +123,7 @@
 	worksound = WORKSOUND_HARD_SLASH
 	force = WEAPON_FORCE_ROBUST
 	throwforce = WEAPON_FORCE_WEAK
-	armor_divisor = ARMOR_PEN_MODERATE
+	armor_penetration = ARMOR_PEN_MODERATE
 	w_class = ITEM_SIZE_SMALL
 	attack_verb = list("stabbed", "chopped", "cut", "sliced", "reaped")
 	tool_qualities = list(QUALITY_CUTTING = 30)

--- a/code/game/objects/items/oddities.dm
+++ b/code/game/objects/items/oddities.dm
@@ -908,7 +908,7 @@
 	slot_flags = SLOT_BELT
 	sharp = TRUE
 	edge = TRUE
-	armor_divisor = ARMOR_PEN_SHALLOW
+	armor_penetration = ARMOR_PEN_SHALLOW
 
 	oddity_stats = list(
 		STAT_ROB = 7

--- a/code/game/objects/items/stacks/throwing.dm
+++ b/code/game/objects/items/stacks/throwing.dm
@@ -21,7 +21,7 @@
 	w_class = ITEM_SIZE_SMALL
 	force = WEAPON_FORCE_NORMAL
 	throwforce = WEAPON_FORCE_WEAK
-	armor_divisor = ARMOR_PEN_SHALLOW
+	armor_penetration = ARMOR_PEN_SHALLOW
 	slot_flags = SLOT_BELT
 
 /obj/item/stack/thrown/update_icon()
@@ -73,7 +73,7 @@
 	w_class = ITEM_SIZE_SMALL
 	force = WEAPON_FORCE_NORMAL
 	throwforce = WEAPON_FORCE_NORMAL
-	armor_divisor = ARMOR_PEN_SHALLOW
+	armor_penetration = ARMOR_PEN_SHALLOW
 	slot_flags = SLOT_BELT
 
 /obj/item/stack/thrown/throwing_knife/launchAt(atom/target, mob/living/carbon/C)

--- a/code/game/objects/items/weapons/hydrogen_melee.dm
+++ b/code/game/objects/items/weapons/hydrogen_melee.dm
@@ -48,7 +48,7 @@
 	active = TRUE
 	force = active_force
 	throwforce = active_throwforce
-	armor_divisor = active_ap
+	armor_penetration = active_ap
 	sharp = TRUE
 	edge = TRUE
 	w_class = active_w_class
@@ -63,7 +63,7 @@
 	active = FALSE
 	force = initial(force)
 	throwforce = initial(throwforce)
-	armor_divisor = initial(armor_divisor)
+	armor_penetration = initial(armor_penetration)
 	sharp = initial(sharp)
 	edge = initial(edge)
 	w_class = initial(w_class)

--- a/code/game/objects/items/weapons/material/misc.dm
+++ b/code/game/objects/items/weapons/material/misc.dm
@@ -5,6 +5,6 @@
 	desc = "Tharr she blows!"
 	icon_state = "harpoon"
 	item_state = "harpoon"
-	armor_divisor = ARMOR_PEN_MODERATE
+	armor_penetration = ARMOR_PEN_MODERATE
 	force_divisor = 0.3 // 18 with hardness 60 (steel)
 	attack_verb = list("jabbed","stabbed","ripped")

--- a/code/game/objects/items/weapons/material/swords.dm
+++ b/code/game/objects/items/weapons/material/swords.dm
@@ -7,7 +7,7 @@
 	icon_state = "claymore"
 	item_state = "claymore"
 	slot_flags = SLOT_BELT
-	armor_divisor = ARMOR_PEN_EXTREME
+	armor_penetration = ARMOR_PEN_EXTREME
 	force_divisor = 0.7 // 42 when wielded with hardnes 60 (steel)
 	thrown_force_divisor = 0.5 // 10 when thrown with weight 20 (steel)
 	sharp = 1

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -5,7 +5,7 @@
 	var/active_w_class
 	sharp = 0
 	edge = 0
-	armor_divisor = ARMOR_PEN_MASSIVE
+	armor_penetration = ARMOR_PEN_MASSIVE
 	flags = NOBLOODY
 	structure_damage_factor = STRUCTURE_DAMAGE_HEAVY
 	heat = 3800
@@ -202,7 +202,7 @@
 	name = "laser dagger"
 	desc = "A much smaller but still useful energy based short blade."
 	clickdelay_offset = FAST_WEAPON_COOLDOWN
-	armor_divisor = ARMOR_PEN_EXTREME
+	armor_penetration = ARMOR_PEN_EXTREME
 	active_force =  WEAPON_FORCE_DANGEROUS
 	active_throwforce =  WEAPON_FORCE_DANGEROUS
 	icon_state = "dagger0"
@@ -278,7 +278,7 @@
 	desc = "A concentrated beam of energy in the shape of a blade. Very stylish... and lethal."
 	icon_state = "blade"
 	icon = 'icons/obj/weapons.dmi'
-	armor_divisor = 2
+	armor_penetration = 2
 	sharp = 1
 	edge = 1
 	force = WEAPON_FORCE_BRUTAL

--- a/code/game/objects/items/weapons/nt_melee.dm
+++ b/code/game/objects/items/weapons/nt_melee.dm
@@ -10,7 +10,7 @@
 	extra_bulk = 3 //a little more size, it's awkward to store out of a sheath.
 	force = WEAPON_FORCE_DANGEROUS
 	throwforce = WEAPON_FORCE_WEAK
-	armor_divisor = ARMOR_PEN_DEEP
+	armor_penetration = ARMOR_PEN_DEEP
 	price_tag = 300
 	matter = list(MATERIAL_BIOMATTER = 25, MATERIAL_STEEL = 5)
 
@@ -30,7 +30,7 @@
 	item_state = "nt_shortsword"
 	force = WEAPON_FORCE_DANGEROUS
 	throwforce = WEAPON_FORCE_WEAK
-	armor_divisor = ARMOR_PEN_DEEP
+	armor_penetration = ARMOR_PEN_DEEP
 	price_tag = 300
 	matter = list(MATERIAL_BIOMATTER = 25, MATERIAL_STEEL = 5)
 
@@ -41,7 +41,7 @@
 	icon_state = "nt_longsword"
 	item_state = "nt_longsword"
 	force = WEAPON_FORCE_ROBUST + 4
-	armor_divisor = ARMOR_PEN_HALF
+	armor_penetration = ARMOR_PEN_DEADLY
 	w_class = ITEM_SIZE_BULKY
 	price_tag = 500
 	matter = list(MATERIAL_BIOMATTER = 50, MATERIAL_STEEL = 10, MATERIAL_PLASTEEL = 5)
@@ -54,7 +54,7 @@
 	icon_state = "nt_dagger"
 	item_state = "nt_dagger"
 	force = WEAPON_FORCE_PAINFUL
-	armor_divisor = ARMOR_PEN_MASSIVE
+	armor_penetration = ARMOR_PEN_MASSIVE
 	price_tag = 120
 	matter = list(MATERIAL_BIOMATTER = 5, MATERIAL_STEEL = 1)
 
@@ -68,7 +68,7 @@
 	item_state = "nt_halberd"
 	wielded_icon = "nt_halberd_wielded"
 	force = WEAPON_FORCE_BRUTAL + 5
-	armor_divisor = ARMOR_PEN_MODERATE
+	armor_penetration = ARMOR_PEN_MODERATE
 	max_upgrades = 3
 	w_class = ITEM_SIZE_HUGE
 	slot_flags = SLOT_BACK
@@ -85,8 +85,8 @@
 	item_state = "nt_scourge"
 	force = WEAPON_FORCE_ROBUST
 	var/force_extended = WEAPON_FORCE_PAINFUL
-	armor_divisor = 1
-	var/armor_divisor_extended = 0.5
+	armor_penetration = 1
+	var/armor_penetration_extended = 0.5
 	var/extended = FALSE
 	var/agony = 20
 	var/agony_extended = 45 //Church harmbaton! This is legit better then a normal baton as it can be upgraded AND has base 15 damage
@@ -105,7 +105,7 @@
 /obj/item/tool/sword/nt/scourge/proc/extend()
 	extended = TRUE
 	force += (force_extended - initial(force))
-	armor_divisor += (armor_divisor_extended - initial(armor_divisor))
+	armor_penetration += (armor_penetration_extended - initial(armor_penetration))
 	agony += (agony_extended - initial(agony))
 	slot_flags = null
 	w_class = ITEM_SIZE_HUGE
@@ -117,7 +117,7 @@
 	w_class = initial(w_class)
 	agony = initial(agony)
 	slot_flags = initial(slot_flags)
-	armor_divisor = initial(armor_divisor)
+	armor_penetration = initial(armor_penetration)
 	refresh_upgrades() //it's also sets all to default
 	update_icon()
 
@@ -147,7 +147,7 @@
 	w_class = ITEM_SIZE_HUGE
 	slot_flags = SLOT_BACK | SLOT_BELT
 	throwforce = WEAPON_FORCE_LETHAL * 1.5
-	armor_divisor = ARMOR_PEN_MASSIVE
+	armor_penetration = ARMOR_PEN_MASSIVE
 	throw_speed = 3
 	price_tag = 450
 	allow_spin = FALSE
@@ -189,7 +189,7 @@
 	icon_state = "nt_flanged"
 	item_state = "nt_flanged"
 	force = WEAPON_FORCE_ROBUST
-	armor_divisor = ARMOR_PEN_HALF
+	armor_penetration = ARMOR_PEN_DEADLY
 	w_class = ITEM_SIZE_BULKY
 	price_tag = 800
 	matter = list(MATERIAL_BIOMATTER = 30, MATERIAL_STEEL = 5, MATERIAL_PLASTEEL = 5, MATERIAL_SILVER = 3)
@@ -241,7 +241,7 @@
 	wielded_icon = "nt_warhammer_wielded"
 	force = WEAPON_FORCE_BRUTAL - 3 //Naturally weaker do to knockbacking are targets (can stun lock)
 	structure_damage_factor = STRUCTURE_DAMAGE_BREACHING
-	armor_divisor = ARMOR_PEN_MODERATE
+	armor_penetration = ARMOR_PEN_MODERATE
 	w_class = ITEM_SIZE_BULKY
 	price_tag = 800
 	matter = list(MATERIAL_BIOMATTER = 30, MATERIAL_STEEL = 5, MATERIAL_PLASTEEL = 8)
@@ -268,7 +268,7 @@
 	switched_on_icon_state = "nt_force_on"
 	switched_on_item_state = "nt_force_on"
 	force = WEAPON_FORCE_DANGEROUS
-	armor_divisor = ARMOR_PEN_MODERATE
+	armor_penetration = ARMOR_PEN_MODERATE
 	w_class = ITEM_SIZE_BULKY
 	no_swing = TRUE
 	f
@@ -457,7 +457,7 @@
 	icon_state = "crusader"
 	item_state = "crusader"
 	force = WEAPON_FORCE_LETHAL
-	armor_divisor = ARMOR_PEN_HALF
+	armor_penetration = ARMOR_PEN_DEADLY
 	matter = list(MATERIAL_DURASTEEL = 25, MATERIAL_GOLD = 3)
 	price_tag = 10000
 
@@ -470,7 +470,7 @@
 	item_state = "nt_shortsword"
 	force = WEAPON_FORCE_DANGEROUS
 	throwforce = WEAPON_FORCE_WEAK
-	armor_divisor = ARMOR_PEN_SHALLOW
+	armor_penetration = ARMOR_PEN_SHALLOW
 	price_tag = 300
 	matter = list(MATERIAL_BIOMATTER = 25, MATERIAL_STEEL = 5)
 
@@ -494,7 +494,7 @@
 	w_class = ITEM_SIZE_HUGE
 	slot_flags = SLOT_BACK | SLOT_BELT
 	throwforce = WEAPON_FORCE_LETHAL
-	armor_divisor = ARMOR_PEN_DEEP
+	armor_penetration = ARMOR_PEN_DEEP
 	throw_speed = 3
 	price_tag = 150
 	allow_spin = FALSE

--- a/code/game/objects/items/weapons/storage.dm
+++ b/code/game/objects/items/weapons/storage.dm
@@ -98,7 +98,7 @@
 				I.no_swing = TRUE
 				I.embed_mult = 0
 				I.force *= damage_mult
-				I.armor_divisor -= ad_loss
+				I.armor_penetration -= ad_loss
 				//This is a uniquic attack proc that has smaller checks, this is to
 				I.fancy_ranged_melee_attack(A, user)
 				I.refresh_upgrades()

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -16,7 +16,7 @@
 	hitsound = 'sound/effects/woodhit.ogg'
 	slot_flags = SLOT_BELT
 	damtype = BRUTE
-	armor_divisor = ARMOR_PEN_SHALLOW
+	armor_penetration = ARMOR_PEN_SHALLOW
 	force = WEAPON_FORCE_ROBUST
 	structure_damage_factor = STRUCTURE_DAMAGE_BLUNT
 
@@ -24,12 +24,12 @@
 	if(user.a_intent == I_HELP)
 		damtype = HALLOSS
 		force = WEAPON_FORCE_PAINFUL
-		armor_divisor = ARMOR_PEN_MODERATE
+		armor_penetration = ARMOR_PEN_MODERATE
 
 	if(user.a_intent == I_DISARM)
 		damtype = HALLOSS
 		force = WEAPON_FORCE_PAINFUL
-		armor_divisor = ARMOR_PEN_SHALLOW
+		armor_penetration = ARMOR_PEN_SHALLOW
 
 	if(user.a_intent == I_HURT)
 		damtype = BRUTE
@@ -111,12 +111,12 @@
 		if(user.a_intent == I_HELP)
 			damtype = HALLOSS
 			force = WEAPON_FORCE_PAINFUL
-			armor_divisor = ARMOR_PEN_MODERATE
+			armor_penetration = ARMOR_PEN_MODERATE
 
 		if(user.a_intent == I_DISARM)
 			damtype = HALLOSS
 			force = 18 //3 more then help but not as good as a wooden classic
-			armor_divisor = ARMOR_PEN_SHALLOW
+			armor_penetration = ARMOR_PEN_SHALLOW
 
 		if(user.a_intent == I_HURT)
 			damtype = BRUTE

--- a/code/game/objects/items/weapons/tools/_tools.dm
+++ b/code/game/objects/items/weapons/tools/_tools.dm
@@ -224,7 +224,7 @@
 	item_stats += list(list( "name" = "Damage", "type" = "ProgressBar", "value" = force, "max" = initial(force) * 10 ))
 	if (extra_bulk)
 		item_stats += list(list( "name" = "Extra Volume", "type" = "AnimatedNumber", "value" = extra_bulk ))
-	item_stats += list(list( "name" = "Armor Divisor", "type" = "AnimatedNumber", "value" = armor_penetration, "max" = 10))
+	item_stats += list(list( "name" = "Armor Penetration", "type" = "AnimatedNumber", "value" = armor_penetration, "max" = 10))
 
 	stats["Item Stats"] = item_stats
 

--- a/code/game/objects/items/weapons/tools/_tools.dm
+++ b/code/game/objects/items/weapons/tools/_tools.dm
@@ -224,7 +224,7 @@
 	item_stats += list(list( "name" = "Damage", "type" = "ProgressBar", "value" = force, "max" = initial(force) * 10 ))
 	if (extra_bulk)
 		item_stats += list(list( "name" = "Extra Volume", "type" = "AnimatedNumber", "value" = extra_bulk ))
-	item_stats += list(list( "name" = "Armor Divisor", "type" = "AnimatedNumber", "value" = armor_divisor, "max" = 10))
+	item_stats += list(list( "name" = "Armor Divisor", "type" = "AnimatedNumber", "value" = armor_penetration, "max" = 10))
 
 	stats["Item Stats"] = item_stats
 
@@ -795,7 +795,7 @@
 	if(switched_on_forcemult)
 		force *= switched_on_forcemult
 	if(switched_on_penmult)
-		armor_divisor *= switched_on_penmult
+		armor_penetration *= switched_on_penmult
 	if(glow_color)
 		set_light(l_range = 1.7, l_power = 1.3, l_color = glow_color)
 	if(switched_on_icon_state)
@@ -821,7 +821,7 @@
 	if(switched_on_forcemult)
 		force /= switched_on_forcemult
 	if(switched_on_penmult)
-		armor_divisor /= switched_on_penmult
+		armor_penetration /= switched_on_penmult
 	if(glow_color)
 		set_light(l_range = 0, l_power = 0, l_color = glow_color)
 	if(switched_on_icon_state)
@@ -946,7 +946,7 @@
 	use_fuel_cost = initial(use_fuel_cost)
 	use_power_cost = initial(use_power_cost)
 	force = initial(force)
-	armor_divisor = initial(armor_divisor)
+	armor_penetration = initial(armor_penetration)
 	damtype = initial(damtype)
 	force_upgrade_mults = initial(force_upgrade_mults)
 	force_upgrade_mods = initial(force_upgrade_mods)
@@ -991,7 +991,7 @@
 		if(switched_on_forcemult)
 			force *= switched_on_forcemult
 		if(switched_on_penmult)
-			armor_divisor *= switched_on_penmult
+			armor_penetration *= switched_on_penmult
 
 	if(wielded)
 		if(force_wielded_multiplier)

--- a/code/game/objects/items/weapons/tools/hammer.dm
+++ b/code/game/objects/items/weapons/tools/hammer.dm
@@ -52,7 +52,7 @@
 	switched_on_qualities = list(QUALITY_HAMMERING = 45)
 	switched_off_qualities = list(QUALITY_HAMMERING = 30)
 	toggleable = TRUE
-	armor_divisor = ARMOR_PEN_EXTREME // Retains AP when turned off - it's a hammer.
+	armor_penetration = ARMOR_PEN_EXTREME // Retains AP when turned off - it's a hammer.
 	degradation = 0.7
 	use_power_cost = 2
 	suitable_cell = /obj/item/cell/medium
@@ -87,7 +87,7 @@
 	item_state = "onehammer"
 	wielded_icon = "onehammer_on"
 	switched_on_forcemult = 2.6 // 39 total
-	armor_divisor = ARMOR_PEN_EXTREME // Retains AP when turned off - it's a hammer.
+	armor_penetration = ARMOR_PEN_EXTREME // Retains AP when turned off - it's a hammer.
 	structure_damage_factor = STRUCTURE_DAMAGE_DESTRUCTIVE
 	matter = list(MATERIAL_STEEL = 4, MATERIAL_PLATINUM = 3, MATERIAL_DIAMOND = 3)
 	price_tag = 860
@@ -109,7 +109,7 @@
 	wielded_icon = "sledgehammer1"
 	force = WEAPON_FORCE_LETHAL
 	slot_flags = SLOT_BELT|SLOT_BACK
-	armor_divisor = ARMOR_PEN_EXTREME
+	armor_penetration = ARMOR_PEN_EXTREME
 	throwforce = WEAPON_FORCE_LETHAL
 	matter = list(MATERIAL_PLASTEEL = 30, MATERIAL_PLASTIC = 5)
 	throw_speed = 1
@@ -128,7 +128,7 @@
 	icon_state = "homewrecker"
 	item_state = "homewrecker0"
 	wielded_icon = "homewrecker1"
-	armor_divisor = ARMOR_PEN_EXTREME
+	armor_penetration = ARMOR_PEN_EXTREME
 	w_class = ITEM_SIZE_BULKY
 	slot_flags = SLOT_BELT|SLOT_BACK
 	force = WEAPON_FORCE_ROBUST
@@ -152,7 +152,7 @@
 	item_state = "iron_hammer"
 	wielded_icon = "iron_hammer_wielded"
 	w_class = ITEM_SIZE_HUGE
-	armor_divisor = ARMOR_PEN_DEEP
+	armor_penetration = ARMOR_PEN_DEEP
 	slot_flags = SLOT_BELT|SLOT_BACK
 	force = WEAPON_FORCE_LETHAL
 	structure_damage_factor = STRUCTURE_DAMAGE_BORING
@@ -169,7 +169,7 @@
 	item_state = "excelsior_hammer"
 	wielded_icon = "excelsior_hammer_wielded"
 	w_class = ITEM_SIZE_HUGE
-	armor_divisor = ARMOR_PEN_DEEP
+	armor_penetration = ARMOR_PEN_DEEP
 	slot_flags = SLOT_BELT
 	force = WEAPON_FORCE_BRUTAL
 	structure_damage_factor = STRUCTURE_DAMAGE_BORING + 2
@@ -186,7 +186,7 @@
 	matter = list(MATERIAL_STEEL = 10)
 	price_tag = 30
 
-	armor_divisor = ARMOR_PEN_DEEP
+	armor_penetration = ARMOR_PEN_DEEP
 	force = WEAPON_FORCE_DANGEROUS
 
 	tool_qualities = list(QUALITY_HAMMERING = 20)
@@ -214,7 +214,7 @@
 	tool_qualities = list(QUALITY_HAMMERING = 5)
 	matter = list(MATERIAL_STEEL = 3)
 	max_upgrades = 3
-	armor_divisor = ARMOR_PEN_GRAZING
+	armor_penetration = ARMOR_PEN_GRAZING
 	force = WEAPON_FORCE_PAINFUL
 	w_class = ITEM_SIZE_HUGE
 
@@ -235,7 +235,7 @@
 	item_state = "chargehammer0"
 	w_class = ITEM_SIZE_HUGE
 	switched_on_forcemult = 2.2
-	armor_divisor = ARMOR_PEN_EXTREME // Retains AP when turned off - it's a hammer.
+	armor_penetration = ARMOR_PEN_EXTREME // Retains AP when turned off - it's a hammer.
 	structure_damage_factor = STRUCTURE_DAMAGE_BREACHING
 	switched_on_qualities = list(QUALITY_HAMMERING = 60)
 	switched_off_qualities = list(QUALITY_HAMMERING = 35)

--- a/code/game/objects/items/weapons/tools/karl.dm
+++ b/code/game/objects/items/weapons/tools/karl.dm
@@ -17,7 +17,7 @@
 
 	// Damage related
 	force = WEAPON_FORCE_DANGEROUS
-	armor_divisor = ARMOR_PEN_EXTREME
+	armor_penetration = ARMOR_PEN_EXTREME
 	throwforce = WEAPON_FORCE_NORMAL
 	sharp = TRUE
 	structure_damage_factor = STRUCTURE_DAMAGE_DESTRUCTIVE // Drills and picks are made for getting through hard materials

--- a/code/game/objects/items/weapons/tools/knifes_daggers.dm
+++ b/code/game/objects/items/weapons/tools/knifes_daggers.dm
@@ -13,7 +13,7 @@
 	w_class = ITEM_SIZE_SMALL
 	force = WEAPON_FORCE_NORMAL
 	throwforce = WEAPON_FORCE_DANGEROUS
-	armor_divisor = ARMOR_PEN_SHALLOW
+	armor_penetration = ARMOR_PEN_SHALLOW
 	clickdelay_offset = FAST_WEAPON_COOLDOWN //small, but quicker to use.
 	max_upgrades = 2
 	tool_qualities = list(QUALITY_CUTTING = 20,  QUALITY_WIRE_CUTTING = 10, QUALITY_SCREW_DRIVING = 5)
@@ -74,7 +74,7 @@
 	matter = list(MATERIAL_PLASTEEL = 3, MATERIAL_PLASTIC = 2)
 	tool_qualities = list(QUALITY_CUTTING = 20,  QUALITY_WIRE_CUTTING = 10, QUALITY_SCREW_DRIVING = 5,  QUALITY_SAWING = 1)
 	force = WEAPON_FORCE_DANGEROUS // Serrated teeth
-	armor_divisor = ARMOR_PEN_MODERATE
+	armor_penetration = ARMOR_PEN_MODERATE
 	throwforce = WEAPON_FORCE_LETHAL
 	price_tag = 35
 
@@ -86,7 +86,7 @@
 	matter = list(MATERIAL_PLASTEEL = 5, MATERIAL_PLASTIC = 2)
 	force = WEAPON_FORCE_DANGEROUS
 	backstab_damage = 8
-	armor_divisor = ARMOR_PEN_EXTREME //Should be countered be embedding
+	armor_penetration = ARMOR_PEN_EXTREME //Should be countered be embedding
 	embed_mult = 1.5 //This is designed for embedding
 
 /obj/item/tool/knife/ritual
@@ -95,7 +95,7 @@
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "render"
 	force = WEAPON_FORCE_PAINFUL
-	armor_divisor = ARMOR_PEN_MODERATE
+	armor_penetration = ARMOR_PEN_MODERATE
 	max_upgrades = 3
 	backstab_damage = 14
 	price_tag = 7
@@ -107,7 +107,7 @@
 	icon_state = "render_awakened"
 	hitsound = 'sound/weapons/renderslash.ogg'
 	force = WEAPON_FORCE_DANGEROUS
-	armor_divisor = ARMOR_PEN_DEEP
+	armor_penetration = ARMOR_PEN_DEEP
 	max_upgrades = 2
 	hitsound = 'sound/weapons/renderslash.ogg'
 	backstab_damage = 8 // Not so much for stabbing as it is for cutting.
@@ -122,7 +122,7 @@
 	force = WEAPON_FORCE_DANGEROUS
 	throwforce = WEAPON_FORCE_DANGEROUS+2
 	backstab_damage = 8
-	armor_divisor = ARMOR_PEN_MODERATE
+	armor_penetration = ARMOR_PEN_MODERATE
 	attack_verb = list("cleaved", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	matter = list(MATERIAL_STEEL = 5, MATERIAL_PLASTIC = 1)
 	tool_qualities = list(QUALITY_CUTTING = 20,  QUALITY_WIRE_CUTTING = 15)
@@ -158,7 +158,7 @@
 	matter = list(MATERIAL_PLASTEEL = 3, MATERIAL_PLASTIC = 2)
 	force = WEAPON_FORCE_DANGEROUS // Serrated combat knife
 	tool_qualities = list(QUALITY_CUTTING = 20,  QUALITY_WIRE_CUTTING = 10, QUALITY_SCREW_DRIVING = 5,  QUALITY_SAWING = 5)
-	armor_divisor = ARMOR_PEN_MODERATE
+	armor_penetration = ARMOR_PEN_MODERATE
 	throwforce = WEAPON_FORCE_LETHAL
 	max_upgrades = 3
 	embed_mult = 0.6
@@ -176,7 +176,7 @@
 	matter = list(MATERIAL_PLASTEEL = 3, MATERIAL_PLASTIC = 2)
 	force = 13
 	backstab_damage = 15
-	armor_divisor = ARMOR_PEN_HALF
+	armor_penetration = ARMOR_PEN_DEADLY
 	throwforce = WEAPON_FORCE_ROBUST
 	price_tag = 21
 
@@ -187,7 +187,7 @@
 	icon = 'icons/obj/weapons.dmi'
 	icon_state = "skinning"
 	item_state = "skinning"
-	armor_divisor = ARMOR_PEN_DEEP
+	armor_penetration = ARMOR_PEN_DEEP
 	tool_qualities = list(QUALITY_CUTTING = 50)
 	matter = list(MATERIAL_PLASTEEL = 8, MATERIAL_WOOD = 2, MATERIAL_DIAMOND = 3) // 5 plasteel + 2 wood, then +3 plasteel +3 diamond from whetstone.
 	price_tag = 500 // Takes diamond to make and very rare.
@@ -213,7 +213,7 @@
 	price_tag = 50 // Fancy expensive heirloom.... it is not exactly meant to be upgradable nor sold but the value that it holds is somehow more symbolic than material.
 	force = WEAPON_FORCE_WEAK
 	throwforce = WEAPON_FORCE_ROBUST
-	armor_divisor = ARMOR_PEN_GRAZING
+	armor_penetration = ARMOR_PEN_GRAZING
 	tool_qualities = list(QUALITY_CUTTING = 35) //Can't be upgraded. Round start knife. Damage is bad not really good to selling either. Only fair give a good status to cutting things.
 	backstab_damage = 9
 

--- a/code/game/objects/items/weapons/tools/pickaxe.dm
+++ b/code/game/objects/items/weapons/tools/pickaxe.dm
@@ -4,7 +4,7 @@
 	flags = CONDUCT
 	slot_flags = SLOT_BELT
 	force = WEAPON_FORCE_DANGEROUS
-	armor_divisor = ARMOR_PEN_EXTREME // It's a pickaxe. It's destined to poke holes in things, even armor.
+	armor_penetration = ARMOR_PEN_EXTREME // It's a pickaxe. It's destined to poke holes in things, even armor.
 	throwforce = WEAPON_FORCE_NORMAL
 	worksound = WORKSOUND_PICKAXE
 	icon_state = "pickaxe"

--- a/code/game/objects/items/weapons/tools/saws.dm
+++ b/code/game/objects/items/weapons/tools/saws.dm
@@ -51,7 +51,7 @@
 	hitsound = WORKSOUND_CIRCULAR_SAW
 	worksound = WORKSOUND_CIRCULAR_SAW
 	force = WEAPON_FORCE_ROBUST
-	armor_divisor = ARMOR_PEN_MODERATE
+	armor_penetration = ARMOR_PEN_MODERATE
 	matter = list(MATERIAL_STEEL = 5, MATERIAL_PLASTIC = 2)
 	tool_qualities = list(QUALITY_SAWING = 45, QUALITY_CUTTING = 30, QUALITY_WIRE_CUTTING = 30)
 	price_tag = 240
@@ -78,7 +78,7 @@
 	name = "advanced circular saw"
 	desc = "You think you can cut anything with it. More power efficient than a regular circular saw."
 	icon_state = "advanced_saw"
-	armor_divisor = ARMOR_PEN_DEEP
+	armor_penetration = ARMOR_PEN_DEEP
 	matter = list(MATERIAL_STEEL = 6, MATERIAL_PLASTEEL = 1, MATERIAL_PLASTIC = 2)
 	tool_qualities = list(QUALITY_SAWING = 50, QUALITY_CUTTING = 40, QUALITY_WIRE_CUTTING = 40)
 	degradation = 0.7
@@ -95,7 +95,7 @@
 	force = WEAPON_FORCE_PAINFUL
 	switched_on_forcemult = 2 //30 total
 	w_class = ITEM_SIZE_NORMAL
-	armor_divisor = ARMOR_PEN_SHALLOW
+	armor_penetration = ARMOR_PEN_SHALLOW
 	matter = list(MATERIAL_STEEL = 3, MATERIAL_PLASTEEL = 10, MATERIAL_PLASTIC = 2)
 	tool_qualities = list(QUALITY_SAWING = 5, QUALITY_CUTTING = 5, QUALITY_WIRE_CUTTING = 5) //barely usable when off, but allows mods to be applied
 	switched_off_qualities = list(QUALITY_CUTTING = 5)
@@ -130,7 +130,7 @@
 	force = 14
 	switched_on_forcemult = 2 //30 total
 	w_class = ITEM_SIZE_NORMAL
-	armor_divisor = ARMOR_PEN_SHALLOW
+	armor_penetration = ARMOR_PEN_SHALLOW
 	matter = list(MATERIAL_SILVER = 2, MATERIAL_PLASTEEL = 10, MATERIAL_PLASTIC = 3)
 	tool_qualities = list(QUALITY_SAWING = 5, QUALITY_CUTTING = 5, QUALITY_WIRE_CUTTING = 5) //barely usable when off, but allows mods to be applied
 	switched_off_qualities = list(QUALITY_CUTTING = 5)

--- a/code/game/objects/items/weapons/tools/scalpels.dm
+++ b/code/game/objects/items/weapons/tools/scalpels.dm
@@ -4,7 +4,7 @@
 	icon_state = "scalpel_t3"
 	flags = CONDUCT
 	force = WEAPON_FORCE_PAINFUL
-	armor_divisor = ARMOR_PEN_SHALLOW
+	armor_penetration = ARMOR_PEN_SHALLOW
 	sharp = TRUE
 	edge = TRUE
 	w_class = ITEM_SIZE_TINY
@@ -37,7 +37,7 @@
 	icon_state = "scalpel_t5"
 	damtype = BURN
 	force = WEAPON_FORCE_DANGEROUS
-	armor_divisor = ARMOR_PEN_MODERATE
+	armor_penetration = ARMOR_PEN_MODERATE
 	matter = list(MATERIAL_PLASTEEL = 1, MATERIAL_PLASTIC = 2, MATERIAL_SILVER = 1)
 	tool_qualities = list(QUALITY_CUTTING = 60, QUALITY_WIRE_CUTTING = 20, QUALITY_LASER_CUTTING = 60, QUALITY_CAUTERIZING = 20)
 	degradation = 0.11

--- a/code/game/objects/items/weapons/tools/shovel.dm
+++ b/code/game/objects/items/weapons/tools/shovel.dm
@@ -44,7 +44,7 @@
 	force = WEAPON_FORCE_DANGEROUS
 	throwforce = WEAPON_FORCE_DANGEROUS
 	w_class = ITEM_SIZE_SMALL
-	armor_divisor = ARMOR_PEN_SHALLOW
+	armor_penetration = ARMOR_PEN_SHALLOW
 	matter = list(MATERIAL_STEEL = 6, MATERIAL_PLASTEEL = 6)
 	tool_qualities = list(QUALITY_SHOVELING = 45, QUALITY_DIGGING = 45, QUALITY_PRYING = 30, QUALITY_CUTTING = 10, QUALITY_SAWING = 5)
 	workspeed = 1.2
@@ -57,7 +57,7 @@
 	force = WEAPON_FORCE_DANGEROUS
 	throwforce = WEAPON_FORCE_DANGEROUS
 	w_class = ITEM_SIZE_SMALL
-	armor_divisor = ARMOR_PEN_SHALLOW
+	armor_penetration = ARMOR_PEN_SHALLOW
 	matter = list(MATERIAL_STEEL = 6, MATERIAL_PLASTEEL = 6)
 	tool_qualities = list(QUALITY_SHOVELING = 85, QUALITY_DIGGING = 85, QUALITY_PRYING = 70, QUALITY_CUTTING = 30, QUALITY_SAWING = 45)
 	workspeed = 1.5

--- a/code/game/objects/items/weapons/tools/simple_weapons.dm
+++ b/code/game/objects/items/weapons/tools/simple_weapons.dm
@@ -46,7 +46,7 @@
 	w_class = ITEM_SIZE_SMALL
 	sharp = TRUE
 	edge = TRUE
-	armor_divisor = ARMOR_PEN_SHALLOW
+	armor_penetration = ARMOR_PEN_SHALLOW
 	origin_tech = list(TECH_MATERIAL = 2, TECH_COMBAT = 1)
 	attack_verb = list("chopped", "torn", "cut")
 	tool_qualities = list(QUALITY_CUTTING = 20, QUALITY_SAWING = 15)
@@ -64,7 +64,7 @@
 	wielded_icon = "fireaxe1"
 	sharp = TRUE
 	edge = TRUE
-	armor_divisor = ARMOR_PEN_DEEP
+	armor_penetration = ARMOR_PEN_DEEP
 	tool_qualities = list(QUALITY_CUTTING = 10, QUALITY_PRYING = 20, QUALITY_SAWING = 15)
 	w_class = ITEM_SIZE_HUGE
 	slot_flags = SLOT_BACK
@@ -127,7 +127,7 @@
 	matter = list(MATERIAL_STEEL = 3, MATERIAL_PLASTEEL = 3)
 	force = WEAPON_FORCE_DANGEROUS
 	throwforce = WEAPON_FORCE_NORMAL
-	armor_divisor = ARMOR_PEN_MODERATE
+	armor_penetration = ARMOR_PEN_MODERATE
 	w_class = ITEM_SIZE_NORMAL
 	attack_verb = list("chopped", "torn", "cut", "cleaved", "slashed")
 	tool_qualities = list(QUALITY_CUTTING = 10)
@@ -244,7 +244,7 @@
 	slot_flags = SLOT_BELT
 	worksound = WORKSOUND_HARD_SLASH
 	force = WEAPON_FORCE_ROBUST
-	armor_divisor = ARMOR_PEN_DEEP
+	armor_penetration = ARMOR_PEN_DEEP
 
 	throwforce = WEAPON_FORCE_NORMAL
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
@@ -270,7 +270,7 @@
 	matter = list(MATERIAL_PLASTEEL = 10, MATERIAL_STEEL = 5, MATERIAL_DIAMOND = 1) //sharpened using diamond dust or whatever
 	slot_flags = SLOT_BELT | SLOT_BACK
 	force = WEAPON_FORCE_BRUTAL
-	armor_divisor = ARMOR_PEN_SHALLOW
+	armor_penetration = ARMOR_PEN_SHALLOW
 	item_icons = list(
 		slot_back_str = 'icons/inventory/back/mob.dmi')
 	item_state_slots = list(
@@ -285,7 +285,7 @@
 	matter = list(MATERIAL_STEEL = 6, MATERIAL_PLASTIC = 2) //twice the value of a kitche knife
 	slot_flags = SLOT_BELT|SLOT_BACK
 	force = WEAPON_FORCE_DANGEROUS
-	armor_divisor = ARMOR_PEN_SHALLOW
+	armor_penetration = ARMOR_PEN_SHALLOW
 	price_tag = 40
 
 /obj/item/tool/sword/katana/nano
@@ -395,7 +395,7 @@
 	icon = 'icons/obj/weapons-blades.dmi'
 	icon_state = "saber"
 	item_state = "saber"
-	armor_divisor = ARMOR_PEN_SHALLOW
+	armor_penetration = ARMOR_PEN_SHALLOW
 	price_tag = 400
 	has_alt_mode = TRUE
 	alt_mode_damagetype = HALLOSS
@@ -419,7 +419,7 @@
 	icon = 'icons/obj/weapons-blades.dmi'
 	icon_state = "saber"
 	item_state = "saber"
-	armor_divisor = ARMOR_PEN_SHALLOW
+	armor_penetration = ARMOR_PEN_SHALLOW
 	price_tag = 350
 
 /obj/item/tool/sword/saber/militiasergeant
@@ -427,7 +427,7 @@
 	desc = "An Saber made for the Senior Enlisted of Blackshield, Usually used for Ceremonial usage but can also be used in combat, Preferably used by a maniac who likes to charge into battle without helmet or armour."
 	icon_state = "cutlass"
 	item_state = "cutlass"
-	armor_divisor = ARMOR_PEN_SHALLOW
+	armor_penetration = ARMOR_PEN_SHALLOW
 	price_tag = 325
 
 /obj/item/tool/sword/saber/deconstuctive_rapier
@@ -437,7 +437,7 @@
 	icon_state = "rapier_cro" //Sprite by Gidgit
 	item_state = "rapiersci"
 	force = WEAPON_FORCE_PAINFUL - 5 //10 base
-	armor_divisor = ARMOR_PEN_MODERATE
+	armor_penetration = ARMOR_PEN_MODERATE
 	price_tag = 1600
 	has_alt_mode = TRUE
 	attack_verb = list("stabbed", "slashed", "pierces")
@@ -487,7 +487,7 @@
 	icon_state = "rapier_cbo"
 	item_state = "rapiermed"
 	force = WEAPON_FORCE_PAINFUL - 5 //10 base
-	armor_divisor = ARMOR_PEN_MODERATE
+	armor_penetration = ARMOR_PEN_MODERATE
 	price_tag = 1600
 	has_alt_mode = TRUE
 	attack_verb = list("stabbed", "slashed", "pierces")
@@ -530,7 +530,7 @@
 		modifier += min(30,H.stats.getStat(STAT_ROB))
 		reagent_modifier = CLAMP(round(H.stats.getStat(STAT_BIO)/10), 1, 5)
 	var/mob/living/L = target
-	if(prob(min(100,((100 / armor_divisor)-L.getarmor(user.targeted_organ, ARMOR_MELEE))+modifier)))
+	if(prob(min(100,((100 / armor_penetration)-L.getarmor(user.targeted_organ, ARMOR_MELEE))+modifier)))
 		var/trans = reagents.trans_to_mob(target, rand(1,3)*reagent_modifier, CHEM_BLOOD)
 		admin_inject_log(user, target, src, reagents.log_list(), trans)
 		to_chat(user, SPAN_NOTICE("You inject [trans] units of the solution. [src] now contains [src.reagents.total_volume] units."))
@@ -542,7 +542,7 @@
 	item_state = "msword"
 	slot_flags = SLOT_BELT|SLOT_BACK
 	matter = list(MATERIAL_PLASTEEL = 5, MATERIAL_STEEL = 2) // 2 rods, 5 plasteel
-	armor_divisor = ARMOR_PEN_MODERATE
+	armor_penetration = ARMOR_PEN_MODERATE
 	tool_qualities = list(QUALITY_CUTTING = 15,  QUALITY_SAWING = 5)
 	degradation = 1.5 // Crappily made
 	max_upgrades = 5 // Handmade nature
@@ -559,7 +559,7 @@
 	item_state = "renderslayer"
 	force = WEAPON_FORCE_BRUTAL + 2 // 35 damage
 	slot_flags = SLOT_BELT|SLOT_BACK
-	armor_divisor = ARMOR_PEN_MASSIVE // Sharp edge
+	armor_penetration = ARMOR_PEN_MASSIVE // Sharp edge
 	effective_faction = list("deathclaw") // Called like this for a reason
 	damage_mult = 2
 	matter = list(MATERIAL_PLASTEEL = 30, MATERIAL_STEEL = 5)
@@ -580,7 +580,7 @@
 	icon_state = "crayon_blade"
 	matter = list(MATERIAL_PLASTEEL = 15, MATERIAL_STEEL = 2, MATERIAL_DIAMOND = 1)
 	force = WEAPON_FORCE_ROBUST + 4 // 30 damage
-	armor_divisor = ARMOR_PEN_MASSIVE // More balanced than psi weapons with psi mania perk.
+	armor_penetration = ARMOR_PEN_MASSIVE // More balanced than psi weapons with psi mania perk.
 	w_class = ITEM_SIZE_BULKY
 	max_upgrades = 2
 	slot_flags = SLOT_BELT|SLOT_BACK
@@ -611,7 +611,7 @@
 	item_state = "cleaver_back"
 	tool_qualities = list(QUALITY_CUTTING = 30)
 	force = WEAPON_FORCE_BRUTAL
-	armor_divisor = ARMOR_PEN_SHALLOW
+	armor_penetration = ARMOR_PEN_SHALLOW
 	w_class = ITEM_SIZE_BULKY
 	effective_faction = list("tengo", "tengolo_berserker", "xenomorph") // Which faction the cleaver is effective against.
 	damage_mult = 2.5 // The damage multiplier the cleaver get when attacking that faction.
@@ -633,7 +633,7 @@
 	slot_flags = SLOT_BELT | SLOT_BACK
 	tool_qualities = list(QUALITY_CUTTING = 20,  QUALITY_SAWING = 20) //Very sharp blade, serrated back
 	force = WEAPON_FORCE_ROBUST
-	armor_divisor = ARMOR_PEN_DEEP // same as other, cheaper swords.
+	armor_penetration = ARMOR_PEN_DEEP // same as other, cheaper swords.
 	effective_faction = list("wurm", "roach", "spider", "vox_tribe", "russian", "tengo", "tengolo_berserker", "xenomorph", "stalker") // This is the janky solution but works.
 	damage_mult = 2 //We are better for hunting, worse for "real fights"
 	w_class = ITEM_SIZE_NORMAL
@@ -646,7 +646,7 @@
 	icon_state = "gauntlet"
 	tool_qualities = list(QUALITY_CUTTING = 20,  QUALITY_SAWING = 20) //Cuts people down just like trees.
 	force = WEAPON_FORCE_BRUTAL
-	armor_divisor = ARMOR_PEN_HALF //same pen as a dagger. This is a fairly rare weapon that require fighting on of the more dangerous mobs.
+	armor_penetration = ARMOR_PEN_DEADLY //same pen as a dagger. This is a fairly rare weapon that require fighting on of the more dangerous mobs.
 	w_class = ITEM_SIZE_NORMAL
 	origin_tech = list(TECH_COMBAT = 5)
 	attack_verb = list("clawed", "scratched", "lacerated", "slashed")
@@ -661,7 +661,7 @@
 	toggleable = TRUE
 	worksound = WORKSOUND_HAMMER
 	switched_on_forcemult = 3.3 //33
-	armor_divisor = ARMOR_PEN_MODERATE
+	armor_penetration = ARMOR_PEN_MODERATE
 	w_class = ITEM_SIZE_NORMAL
 	origin_tech = list(TECH_COMBAT = 7)
 	attack_verb = list("punched", "decked", "haymakered", "uppercut")
@@ -721,7 +721,7 @@
 
 	force = WEAPON_FORCE_PAINFUL
 	throwforce = WEAPON_FORCE_DANGEROUS
-	armor_divisor = ARMOR_PEN_MODERATE
+	armor_penetration = ARMOR_PEN_MODERATE
 	throw_speed = 3
 	max_upgrades = 5
 
@@ -748,7 +748,7 @@
 	wielded_icon = "spear_steel_wielded"
 	force = WEAPON_FORCE_DANGEROUS
 	throwforce = WEAPON_FORCE_ROBUST
-	armor_divisor = ARMOR_PEN_DEEP
+	armor_penetration = ARMOR_PEN_DEEP
 	tool_qualities = list(QUALITY_CUTTING = 10,  QUALITY_WIRE_CUTTING = 5, QUALITY_SCREW_DRIVING = 5)
 	matter = list(MATERIAL_STEEL = 3)
 	structure_damage_factor = STRUCTURE_DAMAGE_WEAK
@@ -761,7 +761,7 @@
 	wielded_icon = "spear_plasteel_wielded"
 	force = WEAPON_FORCE_ROBUST
 	throwforce = WEAPON_FORCE_BRUTAL
-	armor_divisor = ARMOR_PEN_DEEP
+	armor_penetration = ARMOR_PEN_DEEP
 	tool_qualities = list(QUALITY_CUTTING = 15,  QUALITY_WIRE_CUTTING = 10, QUALITY_SCREW_DRIVING = 10)
 	matter = list(MATERIAL_STEEL = 1, MATERIAL_PLASTEEL = 2)
 	structure_damage_factor = STRUCTURE_DAMAGE_NORMAL
@@ -774,7 +774,7 @@
 	wielded_icon = "spear_uranium_wielded"
 	force = WEAPON_FORCE_DANGEROUS
 	throwforce = WEAPON_FORCE_DANGEROUS
-	armor_divisor = ARMOR_PEN_DEEP
+	armor_penetration = ARMOR_PEN_DEEP
 	tool_qualities = list(QUALITY_CUTTING = 10,  QUALITY_WIRE_CUTTING = 5, QUALITY_SCREW_DRIVING = 5)
 	matter = list(MATERIAL_STEEL = 3, MATERIAL_URANIUM = 1)
 
@@ -791,7 +791,7 @@
 	wielded_icon = "makeshift_halberd_wielded"
 	force = WEAPON_FORCE_ROBUST
 	throwforce = WEAPON_FORCE_NORMAL
-	armor_divisor = ARMOR_PEN_SHALLOW
+	armor_penetration = ARMOR_PEN_SHALLOW
 	tool_qualities = list(QUALITY_CUTTING = 10)
 	matter = list(MATERIAL_STEEL = 5)
 
@@ -803,7 +803,7 @@
 	item_state = "hunter_halberd"
 	wielded_icon = "hunter_halberd_wielded"
 	force = WEAPON_FORCE_BRUTAL
-	armor_divisor = ARMOR_PEN_DEEP
+	armor_penetration = ARMOR_PEN_DEEP
 	effective_faction = list("wurm", "roach", "spider", "vox_tribe", "russian", "tengo", "tengolo_berserker", "xenomorph", "stalker") // This is the janky solution but works.
 	damage_mult = 2 //We are better for hunting, worse for "real fights"
 	price_tag = 500
@@ -823,7 +823,7 @@
 	slot_flags = SLOT_BELT
 	worksound = WORKSOUND_HARD_SLASH
 	force = WEAPON_FORCE_ROBUST
-	armor_divisor = ARMOR_PEN_DEEP
+	armor_penetration = ARMOR_PEN_DEEP
 
 	throwforce = WEAPON_FORCE_NORMAL
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
@@ -854,7 +854,7 @@
 	icon_state = "katana_old"
 	item_state = "katana"
 	force = WEAPON_FORCE_DANGEROUS
-	armor_divisor = ARMOR_PEN_EXTREME
+	armor_penetration = ARMOR_PEN_EXTREME
 
 /obj/item/tool/cheap/spear
 	name = "cheap spear"

--- a/code/game/objects/items/weapons/tools/surgicaldrills.dm
+++ b/code/game/objects/items/weapons/tools/surgicaldrills.dm
@@ -7,7 +7,7 @@
 	matter = list(MATERIAL_STEEL = 4, MATERIAL_PLASTIC = 2)
 	flags = CONDUCT
 	force = WEAPON_FORCE_DANGEROUS
-	armor_divisor = ARMOR_PEN_MODERATE
+	armor_penetration = ARMOR_PEN_MODERATE
 	w_class = ITEM_SIZE_NORMAL
 	origin_tech = list(TECH_MATERIAL = 1, TECH_BIO = 1)
 	attack_verb = list("drilled")
@@ -22,7 +22,7 @@
 	desc = "A handheld drill with a longer and more durable drill, for precision drilling."
 	icon_state = "longdrill"
 	force = WEAPON_FORCE_ROBUST
-	armor_divisor = ARMOR_PEN_DEEP //Diamond tip!
+	armor_penetration = ARMOR_PEN_DEEP //Diamond tip!
 	matter = list(MATERIAL_STEEL = 6, MATERIAL_PLASTIC = 2, MATERIAL_DIAMOND = 1)
 	tool_qualities = list(QUALITY_DRILLING = 60)
 	use_power_cost = 0.60
@@ -31,5 +31,5 @@
 /obj/item/tool/surgicaldrill/adv/si
 	icon_state = "drill_SI"
 	matter = list(MATERIAL_STEEL = 8, MATERIAL_PLASTIC = 4, MATERIAL_PLASTEEL = 1) //we use a plasteel tip rather then diamond, thus less AP
-	armor_divisor = ARMOR_PEN_MODERATE
+	armor_penetration = ARMOR_PEN_MODERATE
 	price_tag = 450

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -10,7 +10,7 @@
 	var/edge = 0		// whether this object is more likely to dismember
 	var/in_use = 0 // If we have a user using us, this will be set on. We will check if the user has stopped using us, and thus stop updating and LAGGING EVERYTHING!
 	var/damtype = BRUTE
-	var/armor_divisor = 1
+	var/armor_penetration = 1
 	var/corporation = null
 	var/heat = 0
 	//soj edit
@@ -257,7 +257,7 @@
 
 //Same for AP
 /obj/proc/add_projectile_penetration(newmult)
-	armor_divisor = initial(armor_divisor) + newmult
+	armor_penetration = initial(armor_penetration) + newmult
 
 /obj/proc/multiply_pierce_penetration(newmult)
 

--- a/code/modules/clothing/accessories/holster.dm
+++ b/code/modules/clothing/accessories/holster.dm
@@ -463,7 +463,7 @@ Sword holsters
 				I.no_swing = TRUE
 				I.embed_mult = 0
 				I.force *= damage_mult
-				I.armor_divisor -= ad_loss
+				I.armor_penetration -= ad_loss
 				//This is a uniquic attack proc that has smaller checks, this is to
 				I.fancy_ranged_melee_attack(A, user)
 				I.refresh_upgrades()

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -779,11 +779,11 @@
 	for(var/damage_type in P.damage_types)
 		if(damage_type in list(BRUTE, BURN)) // Ablative armor affects both brute and burn damage
 			var/damage = P.damage_types[damage_type]
-			P.damage_types[damage_type] -= ablative_stack / armor_divisor
+			P.damage_types[damage_type] -= ablative_stack / armor_penetration
 
 			ablative_stack = max(ablative_stack - damage, 0)
 		else if(damage_type == HALLOSS)
-			P.damage_types[damage_type] -= ablative_stack / armor_divisor
+			P.damage_types[damage_type] -= ablative_stack / armor_penetration
 
 		if(P.damage_types[damage_type] <= 0)
 			P.damage_types -= damage_type

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -25,7 +25,7 @@
 		weapon_edge = 0
 
 	hit_impact(effective_force, get_step(user, src), hit_zone)
-	damage_through_armor(effective_force, I.damtype, hit_zone, ARMOR_MELEE, armor_divisor = I.armor_divisor, used_weapon = I, sharp = weapon_sharp, edge = weapon_edge)
+	damage_through_armor(effective_force, I.damtype, hit_zone, ARMOR_MELEE, armor_penetration = I.armor_penetration, used_weapon = I, sharp = weapon_sharp, edge = weapon_edge)
 
 /*Its entirely possible that we were gibbed or dusted by the above. Check if we still exist before
 continuing. Being gibbed or dusted has a 1.5 second delay, during which it sets the transforming var to

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -316,7 +316,7 @@
 	var/penetration = 1
 	if(istype(user, /mob/living))
 		var/mob/living/L = user
-		penetration = L.armor_divisor
+		penetration = L.armor_penetration
 
 	user.attack_log += text("\[[time_stamp()]\] <font color='red'>attacked [src.name] ([src.ckey])</font>")
 	src.attack_log += text("\[[time_stamp()]\] <font color='orange'>was attacked by [user.name] ([user.ckey])</font>")
@@ -331,7 +331,7 @@
 
 	var/dam_zone = pick(organs_by_name)
 	var/obj/item/organ/external/affecting = get_organ(ran_zone(dam_zone))
-	var/dam = damage_through_armor(damage = damage, damagetype = damagetype, def_zone = affecting, attack_flag = ARMOR_MELEE, armor_divisor = penetration, sharp = sharp, edge = sharp)
+	var/dam = damage_through_armor(damage = damage, damagetype = damagetype, def_zone = affecting, attack_flag = ARMOR_MELEE, armor_penetration = penetration, sharp = sharp, edge = sharp)
 
 	// ran_zone might pick a zone that we don't actually have an organ in
 	if(dam > 0 && affecting)

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -337,7 +337,7 @@ This function restores all organs.
 		zone = BP_HEAD
 	return organs_by_name[zone]
 
-/mob/living/carbon/human/apply_damage(damage = 0, damagetype = BRUTE, def_zone, armor_divisor = 1, wounding_multiplier = 1, sharp = FALSE, edge = FALSE, obj/used_weapon, armor_divisor)
+/mob/living/carbon/human/apply_damage(damage = 0, damagetype = BRUTE, def_zone, armor_penetration = 1, wounding_multiplier = 1, sharp = FALSE, edge = FALSE, obj/used_weapon, armor_penetration)
 
 	//visible_message("Hit debug. [damage] | [damagetype] | [def_zone] | [blocked] | [sharp] | [used_weapon]")
 
@@ -355,7 +355,7 @@ This function restores all organs.
 		if(damagetype == PSY)
 			sanity.onPsyDamage(damage)
 			var/obj/item/organ/brain = random_organ_by_process(BP_BRAIN)
-			brain.take_damage(damage, PSY, (armor_divisor * 0.1), wounding_multiplier)
+			brain.take_damage(damage, PSY, (armor_penetration * 0.1), wounding_multiplier)
 			return TRUE
 
 		if(damagetype == TOX && stats.getPerk(PERK_BLOOD_OF_LEAD))
@@ -382,7 +382,7 @@ This function restores all organs.
 		return FALSE
 
 	damageoverlaytemp = 20
-	if(organ.take_damage(damage, damagetype, armor_divisor, wounding_multiplier, sharp, edge, used_weapon))
+	if(organ.take_damage(damage, damagetype, armor_penetration, wounding_multiplier, sharp, edge, used_weapon))
 		UpdateDamageIcon()
 
 	sanity.onDamage(damage)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -618,7 +618,7 @@ uniquic_armor_act
 					if(en_passant)
 					//	message_admins("unique_armor_check en_passant ranged")
 					//	message_admins("prj ranged [Proj.penetrating]")
-						Proj.armor_divisor *= 0.5
+						Proj.armor_penetration *= 0.5
 						Proj.check_armour = ARMOR_MELEE //Foolishness
 						Proj.fire_stacks = 0   //No witches here
 						Proj.wounding_mult = 1 //Foolishness!
@@ -635,7 +635,7 @@ uniquic_armor_act
 					else
 					//	message_admins("unique_armor_check en_passant ranged")
 					//	message_admins("prj ranged [Proj.penetrating]")
-						Proj.armor_divisor *= 2
+						Proj.armor_penetration *= 2
 						if(Proj.damage_types[BRUTE])
 						//	message_admins("prj BRUTE [Proj.damage_types[BRUTE]] Pre")
 							Proj.damage_types[BRUTE] *= 1.5

--- a/code/modules/mob/living/carbon/human/species/species_attack.dm
+++ b/code/modules/mob/living/carbon/human/species/species_attack.dm
@@ -53,7 +53,7 @@
 	attack_verb = list("stabbed", "jabbed", "shanked")
 	attack_noun = list("stab", "jab", "shank")
 	damage = 2
-	armor_divisor = 1.2
+	armor_penetration = 2
 
 /datum/unarmed_attack/horns
 	deal_halloss = 9

--- a/code/modules/mob/living/carbon/human/unarmed_attack.dm
+++ b/code/modules/mob/living/carbon/human/unarmed_attack.dm
@@ -10,7 +10,7 @@ var/global/list/sparring_attack_cache = list()
 	var/shredding = 0 // Calls the old attack_alien() behavior on objects/mobs when on harm intent.
 	var/sharp = 0
 	var/edge = 0
-	var/armor_divisor = 1
+	var/armor_penetration = 1
 
 	var/deal_halloss
 	var/sparring_variant_type = /datum/unarmed_attack/light_strike

--- a/code/modules/mob/living/carbon/superior_animal/defense.dm
+++ b/code/modules/mob/living/carbon/superior_animal/defense.dm
@@ -404,9 +404,9 @@
 	var/penetration = 1
 	if(istype(user, /mob/living))
 		var/mob/living/L = user
-		penetration = L.armor_divisor
+		penetration = L.armor_penetration
 
-	damage_through_armor(damage, BRUTE, attack_flag=ARMOR_MELEE, armor_divisor=penetration)
+	damage_through_armor(damage, BRUTE, attack_flag=ARMOR_MELEE, armor_penetration=penetration)
 	user.attack_log += text("\[[time_stamp()]\] <font color='red'>attacked [src.name] ([src.ckey])</font>")
 	src.attack_log += text("\[[time_stamp()]\] <font color='orange'>was attacked by [user.name] ([user.ckey])</font>")
 	src.visible_message(SPAN_DANGER("[user] has [attack_message] [src]!"))

--- a/code/modules/mob/living/carbon/superior_animal/giant_spider/giant_spider.dm
+++ b/code/modules/mob/living/carbon/superior_animal/giant_spider/giant_spider.dm
@@ -18,7 +18,7 @@
 	speak_chance = 5
 
 	get_stat_modifier = FALSE //We're too baby to get extra mods.
-	armor_divisor = 1
+	armor_penetration = 1
 
 	armor = list(melee = 1, bullet = 0, energy = 0, bomb = 1, bio = 10, rad = 25)
 

--- a/code/modules/mob/living/carbon/superior_animal/giant_spider/types/hunter/hunter.dm
+++ b/code/modules/mob/living/carbon/superior_animal/giant_spider/types/hunter/hunter.dm
@@ -51,7 +51,7 @@
 	meat_type = /obj/item/reagent_containers/food/snacks/meat/spider/plasma
 	meat_amount = 4
 	emote_see = list("chitters.","rubs its legs.","vibrates.")
-	armor_divisor = 3
+	armor_penetration = 3
 
 /mob/living/carbon/superior_animal/giant_spider/plasma/UnarmedAttack(var/atom/A, var/proximity)
 	. = ..()
@@ -205,7 +205,7 @@
 	poison_type = "party drops"
 	meat_type = /obj/item/reagent_containers/food/snacks/meat/spider/emperor
 	armor = list(melee = 6, bullet = 6, energy = 2, bomb = 25, bio = 10, rad = 25, agony = 0)
-	armor_divisor = 2
+	armor_penetration = 2
 
 	get_stat_modifier = TRUE //Were not getting armor //Yes we are.
 
@@ -238,7 +238,7 @@
 	poison_per_bite = 6
 	poison_type = "stoxin"
 	meat_type = /obj/item/reagent_containers/food/snacks/meat/spider/reaper_spider
-	armor_divisor = 3
+	armor_penetration = 3
 
 	get_stat_modifier = FALSE //Were not getting armor
 

--- a/code/modules/mob/living/carbon/superior_animal/giant_spider/types/nurse.dm
+++ b/code/modules/mob/living/carbon/superior_animal/giant_spider/types/nurse.dm
@@ -106,7 +106,7 @@
 	move_to_delay = 5 // Very slow do to being 1 hit unfun
 	//Giving the recluse its own special meat that has zombie powder. Reducing the amount of meat made since this is some hard stuff and the recluse is easy to kill.
 	poison_type = "zombiepowder"
-	armor_divisor = 3
+	armor_penetration = 3
 
 /mob/living/carbon/superior_animal/giant_spider/nurse/queen
 	name = "empress spider"
@@ -129,7 +129,7 @@
 	get_stat_modifier =  TRUE
 	armor = list(melee = 3, bullet = 1, energy = 0, bomb = 5, bio = 10, rad = 25, agony = 0)
 	inherent_mutations = list(MUTATION_GIGANTISM, MUTATION_SPIDER_FRIEND, MUTATION_RAND_UNSTABLE, MUTATION_RAND_UNSTABLE, MUTATION_RAND_UNSTABLE)
-	armor_divisor = 2
+	armor_penetration = 2
 
 /mob/living/carbon/superior_animal/giant_spider/nurse/queen/New()
 	..()

--- a/code/modules/mob/living/carbon/superior_animal/human/subtype/excelsior/excelsior.dm
+++ b/code/modules/mob/living/carbon/superior_animal/human/subtype/excelsior/excelsior.dm
@@ -115,7 +115,7 @@
 
 	melee_damage_lower = 33
 	melee_damage_upper = 40
-	armor_divisor = ARMOR_PEN_DEEP
+	armor_penetration = ARMOR_PEN_DEEP
 
 	ranged = 0
 	rapid = 0

--- a/code/modules/mob/living/carbon/superior_animal/human/subtype/voidwolf/voidwolf.dm
+++ b/code/modules/mob/living/carbon/superior_animal/human/subtype/voidwolf/voidwolf.dm
@@ -14,7 +14,7 @@
 	melee_damage_upper = 30
 
 	melee_sharp = FALSE //Eswords
-	armor_divisor = 3
+	armor_penetration = 3
 
 	breath_required_type = 0 // Doesn't need to breath, in a space suit
 	breath_poison_type = 0 // Can't be poisoned
@@ -105,7 +105,7 @@
 	attack_sound = 'sound/items/Welder.ogg'
 	drop_items = list(/obj/item/tool/weldingtool/advanced)
 	melee_sharp = FALSE
-	armor_divisor = 1
+	armor_penetration = 2
 	melee_damage_type = BURN
 
 /*Ranged Void Wolfs*/
@@ -131,7 +131,7 @@
 	mag_type = /obj/item/cell/medium/high/depleted
 	mags_left = 1
 	melee_sharp = FALSE
-	armor_divisor = 1
+	armor_penetration = 1
 
 /mob/living/carbon/superior_animal/human/voidwolf/ranged/New()
 	..()
@@ -155,7 +155,7 @@
 	mag_type = /obj/item/cell/small/high/depleted
 	mags_left = 2
 	melee_sharp = FALSE
-	armor_divisor = 1
+	armor_penetration = 3
 	melee_damage_type = BURN
 
 /mob/living/carbon/superior_animal/human/voidwolf/fieldtech/ranged/New()
@@ -175,7 +175,7 @@
 	projectiletype = /obj/item/projectile/beam
 	drop_items = list(/obj/item/gun/energy/cog)
 	melee_sharp = FALSE
-	armor_divisor = 1
+	armor_penetration = 1
 
 /mob/living/carbon/superior_animal/human/voidwolf/ranged/aerotrooper/New()
 	..()
@@ -201,7 +201,7 @@
 	mag_type = /obj/item/cell/small/high/depleted
 	mags_left = 1
 	melee_sharp = TRUE //Eswords
-	armor_divisor = 3
+	armor_penetration = 4
 
 	times_to_get_stat_modifiers = 2 //two prefixes
 
@@ -231,7 +231,7 @@
 
 	flash_resistances = 20 //no.
 	melee_sharp = TRUE //Eswords
-	armor_divisor = 3
+	armor_penetration = 5
 	armor = list(melee = 15, bullet = 13, energy = 12, bomb = 75, bio = 100, rad = 25) //Legitmently their armor
 
 /mob/living/carbon/superior_animal/human/voidwolf/elite/New()
@@ -254,7 +254,7 @@
 	rapid_fire_shooting_amount = 5 //we're using the burst 5 mode
 	delay_for_rapid_range = 0.22 SECONDS
 	melee_sharp = FALSE
-	armor_divisor = 1
+	armor_penetration = 2
 
 /obj/item/gun/energy/firestorm/reaver_modded
 
@@ -279,7 +279,7 @@
 
 	casingtype = /obj/item/ammo_casing/pistol_35/spent
 	melee_sharp = FALSE
-	armor_divisor = 1
+	armor_penetration = 3
 
 /obj/item/gun/projectile/automatic/c20r/reaver_modded
 
@@ -311,7 +311,7 @@
 
 casingtype = /obj/item/ammo_casing/a75/spent
 	melee_sharp = FALSE
-	armor_divisor = 1
+	armor_penetration = 1
 
 /mob/living/carbon/superior_animal/human/voidwolf/elite/gyrojet/New()
 	..()
@@ -330,7 +330,7 @@ casingtype = /obj/item/ammo_casing/a75/spent
 	drop_items = list(/obj/item/tool/sword/saber/cutlass, /obj/item/shield/buckler/energy/reaver/damaged,/obj/random/cloth/assault/reaver)
 
 	melee_sharp = TRUE //Eswords
-	armor_divisor = 3
+	armor_penetration = 3
 	var/block_chance = 65
 
 /mob/living/carbon/superior_animal/human/voidwolf/elite/myrmidon/New()

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/Ploge.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/Ploge.dm
@@ -29,7 +29,7 @@
 	can_burrow = FALSE
 	melee_damage_lower = 15
 	melee_damage_upper = 25
-	armor_divisor = 3
+	armor_penetration = 6
 	ranged = TRUE
 
 	pixel_x = 0
@@ -61,7 +61,7 @@
 		knockdown_odds = 50
 		melee_damage_lower = 30
 		melee_damage_upper = 35
-		armor_divisor = 4
+		armor_penetration = 4
 		transform_ed = TRUE
 		projectiletype = /obj/item/projectile/tether/lash
 		for(var/mob/living/target in targets_in_range(in_hear_range = TRUE))

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/PsiImpressive.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/PsiImpressive.dm
@@ -19,7 +19,7 @@
 	death_gasp = "<b><font size='3px'>The flesh behemoth heaves as its body crumbles, wriggling pus maggots bursting from its failing rotted bulk!</font></b>!"
 	drop_items = list(/obj/random/psi/always_spawn, /obj/random/psi/always_spawn)
 	momento_mori = /obj/effect/decal/cleanable/psi_ash/flesh_behemoth
-	armor_divisor = 1
+	armor_penetration = 3
 
 
 /mob/living/carbon/superior_animal/psi_monster/mind_gazer
@@ -37,7 +37,7 @@
 	healing_factor = 10
 	attacktext = "rammed"
 	drop_items = list(/obj/random/psi/always_spawn, /obj/random/psi/always_spawn)
-	armor_divisor = 1.2
+	armor_penetration = 2
 	leach_on_odds = 30
 	can_leach = TRUE
 	steal_odds = 15
@@ -63,7 +63,7 @@
 	light_color = COLOR_LIGHTING_RED_BRIGHT
 	attacktext = "clawed"
 	drop_items = list(/obj/random/psi/always_spawn, /obj/random/psi/always_spawn)
-	armor_divisor = 1.5
+	armor_penetration = 3
 
 /mob/living/carbon/superior_animal/psi_monster/cerebral_crusher
 	name = "cerebral crusher"
@@ -82,7 +82,7 @@
 	healing_factor = 10
 	attacktext = "slammed"
 	drop_items = list(/obj/random/psi/always_spawn, /obj/random/psi/always_spawn)
-	armor_divisor = 1.3
+	armor_penetration = 5
 
 /mob/living/carbon/superior_animal/psi_monster/wasonce/crimson_jelly
 	name = "crimson jelly"
@@ -106,7 +106,7 @@
 	knockdown_odds = 15
 	armor = list(melee = 5, bullet = 2, energy = 1, bomb = 30, bio = 100, rad = 100)
 	drop_items = list(/obj/random/psi/always_spawn, /obj/random/psi/weapons/always_spawn)
-	armor_divisor = 2.3
+	armor_penetration = 2
 
 /mob/living/carbon/superior_animal/psi_monster/wasonce/crimson_jelly/pitch_horror
 	name = "pitch horror"
@@ -119,7 +119,7 @@
 	health = 1250 * PSIMOB_HEALTH_MOD
 	knockdown_odds = 30
 	drop_items = list(/obj/random/psi/always_spawn, /obj/random/psi/weapons/always_spawn, /obj/random/psi/always_spawn, /obj/random/psi/weapons/always_spawn)
-	armor_divisor = 4
+	armor_penetration = 6
 
 // King's Court. Special named psi mobs with better stats and custom voice lines, they are spawned whenever the king of the hound journey.
 /mob/living/carbon/superior_animal/psi_monster/flesh_behemoth/baron

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/PsiMega.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/PsiMega.dm
@@ -20,7 +20,7 @@
 	default_pixel_x = -16
 	default_pixel_y = 0
 	size_pixel_offset_x = -16
-	armor_divisor = 4
+	armor_penetration = 12
 	momento_mori = /obj/effect/decal/cleanable/psi_ash/king
 	first_teleport_callout = "<b><font size='3px'>\the Dreaming King looses a terrible scream before journeying to nowhere, his words bellowing in rage, \"Only the king may wear the crown!\" The answering calls of his court echoing through the realm!</font></b>"
 	second_teleport_callout = "<b><font size='3px'>\the Dreaming King looses an agonized howl before journeying to nowhere, his words bellowing in rage, \"I will never die!\" The strongest of his court heard affirming his call!</font></b>"

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/PsiRobust.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/PsiRobust.dm
@@ -14,7 +14,7 @@
 	turns_per_move = 4 // Slow
 	attacktext = "punched"
 	momento_mori = /obj/effect/decal/cleanable/psi_ash/ponderous
-	armor_divisor = 3
+	armor_penetration = 3
 
 /mob/living/carbon/superior_animal/psi_monster/hovering_nightmare
 	name = "hovering nightmare"
@@ -27,7 +27,7 @@
 	health = 100 * PSIMOB_HEALTH_MOD
 	melee_damage_lower = 20
 	melee_damage_upper = 25
-	armor_divisor = 1.5
+	armor_penetration = 2
 	emote_see = list("begins to melt, blackened skin sloughing down its form until it pulls taut.", "howls, \"Birth, flesh, death, decay, birth, flesh, death, decay!\"", "howls in agony!")
 	turns_per_move = 10
 	leach_on_odds = 10
@@ -52,7 +52,7 @@
 	poison_per_bite = 3
 	poison_type = "xenotoxin"
 	attacktext = "tongued"
-	armor_divisor = 2
+	armor_penetration = 2
 
 /mob/living/carbon/superior_animal/psi_monster/memory
 	name = "memory"
@@ -67,7 +67,7 @@
 	emote_see = list("screams, \"They did this they did this!\"", "howls, \"They could have done something!\"", "whispers, \"I could have done something...\"", "groans, \"Kill me, please...\"", "weeps, \"It will never end.\"")
 	speak_chance = 15
 	attacktext = "stroked"
-	armor_divisor = 1
+	armor_penetration = 2
 	leach_on_odds = 70
 	can_leach = TRUE
 	steal_odds = 5

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/PsiTrash.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/PsiTrash.dm
@@ -17,7 +17,7 @@
 	chameleon_skill = 1
 	speak_chance = 2
 	attacktext = "clawed"
-	armor_divisor = 1.2
+	armor_penetration = 1
 
 /mob/living/carbon/superior_animal/psi_monster/thought_melter
 	name = "thought melter"
@@ -33,7 +33,7 @@
 	speak_chance = 10
 	poison_per_bite = 1
 	attacktext = "caressed"
-	armor_divisor = 1.5
+	armor_penetration = 1
 
 /mob/living/carbon/superior_animal/psi_monster/pus_maggot
 	name = "pus maggot"
@@ -45,7 +45,7 @@
 	health = 110 * PSIMOB_HEALTH_MOD
 	melee_damage_lower = 10
 	melee_damage_upper = 15
-	armor_divisor = 1.2
+	armor_penetration = 1
 	emote_see = list("drools acid onto the floor.", "wriggles in glee!", "rolls over!")
 	var/burn_attack_text = "The pus maggot vomits up some acidic pus all over!"
 	var/burn_attack_sound = 'sound/effects/splat.ogg'

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/corrupted_beings.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/corrupted_beings.dm
@@ -22,7 +22,7 @@
 	special_parts = list(/obj/item/animal_part/chimera_fang)
 
 
-	armor_divisor = 2 //Sharp bones
+	armor_penetration = 2 //Sharp bones
 
 
 	//Good stats baseline in case admins dont edit these
@@ -54,7 +54,7 @@
 	colony_friend = FALSE
 	friendly_to_colony = FALSE
 
-	armor_divisor = 1.25
+	armor_penetration = 1.25
 
 	color = "#49D6F2"
 
@@ -103,7 +103,7 @@ They are soully made and reflavoured to be for PVE.
 	move_to_delay = 1
 	attacktext = "rends apart"
 
-	armor_divisor = 2.5
+	armor_penetration = 2.5
 
 	color = null
 
@@ -200,7 +200,7 @@ They are soully made and reflavoured to be for PVE.
 
 	drop_items = list(/obj/item/tool/sword/cleaver/cult/deepmaints)
 
-	armor_divisor = 1.25
+	armor_penetration = 1.25
 
 /mob/living/carbon/superior_animal/psi_monster/daskvey_follower/cleaver/deepmaints_bound
 	name = "Wild Daskveyian Wall Breaker"
@@ -236,7 +236,7 @@ They are soully made and reflavoured to be for PVE.
 	comfy_range = 6
 	projectiletype = /obj/item/projectile/plasma/aoe/heat
 
-	armor_divisor = 1
+	armor_penetration = 1
 
 /mob/living/carbon/superior_animal/psi_monster/daskvey_follower/plasma/deepmaints_bound
 	name = "Wild Daskveyian Plasma Caster"
@@ -273,7 +273,7 @@ They are soully made and reflavoured to be for PVE.
 	comfy_range = 6
 	projectiletype = /obj/item/projectile/beam
 
-	armor_divisor = 1
+	armor_penetration = 1
 
 /mob/living/carbon/superior_animal/psi_monster/daskvey_follower/laser/deepmaints_bound
 	name = "Wild Daskveyian Las-Gunner"
@@ -314,7 +314,7 @@ They are soully made and reflavoured to be for PVE.
 	projectiletype = /obj/item/projectile/bullet/pistol_35/scrap
 	mag_type = /obj/item/ammo_magazine/smg_35/empty
 
-	armor_divisor = 1
+	armor_penetration = 1
 
 /mob/living/carbon/superior_animal/psi_monster/daskvey_follower/smg/Initialize(mapload)
 	. = ..()
@@ -361,7 +361,7 @@ They are soully made and reflavoured to be for PVE.
 	projectiletype = /obj/item/projectile/bullet/rifle_75/scrap
 	mag_type = /obj/item/ammo_magazine/rifle_75/empty
 
-	armor_divisor = 1
+	armor_penetration = 1
 
 /mob/living/carbon/superior_animal/psi_monster/daskvey_follower/rifle/Initialize(mapload)
 	. = ..()
@@ -394,7 +394,7 @@ They are soully made and reflavoured to be for PVE.
 
 	drop_items = list()
 
-	armor_divisor = 1
+	armor_penetration = 1
 	armor = list(melee = 15, bullet = 15, energy = 3, bomb = 100, bio = 100, rad = 90)
 	var/knockdown_odds = 30
 
@@ -435,7 +435,7 @@ They are soully made and reflavoured to be for PVE.
 
 	drop_items = list()
 
-	armor_divisor = 1.5
+	armor_penetration = 1.5
 	armor = list(melee = 15, bullet = 15, energy = 3, bomb = 100, bio = 100, rad = 90)
 
 /mob/living/carbon/superior_animal/psi_monster/daskvey_follower/halberd/deepmaints_bound
@@ -463,7 +463,7 @@ They are soully made and reflavoured to be for PVE.
 
 	drop_items = list()
 
-	armor_divisor = 1
+	armor_penetration = 1
 	armor = list(melee = 0, bullet = 0, energy = 0, bomb = 0, bio = 0, rad = 0)
 
 /mob/living/carbon/superior_animal/psi_monster/daskvey_follower/weakling/deepmaints_bound
@@ -491,7 +491,7 @@ They are soully made and reflavoured to be for PVE.
 
 	drop_items = list()
 
-	armor_divisor = 1
+	armor_penetration = 1
 	armor = list(melee = 0, bullet = 0, energy = 0, bomb = 0, bio = 0, rad = 0)
 
 	rounds_per_fire = 1
@@ -540,7 +540,7 @@ They are soully made and reflavoured to be for PVE.
 
 	drop_items = list()
 
-	armor_divisor = 1
+	armor_penetration = 1
 	armor = list(melee = 0, bullet = 0, energy = 0, bomb = 0, bio = 0, rad = 0)
 
 	rounds_per_fire = 1

--- a/code/modules/mob/living/carbon/superior_animal/roach/types/bluespace.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/types/bluespace.dm
@@ -15,7 +15,7 @@
 */
 	price_tag = 1500
 	flash_resistances = 15 //We are the light
-	armor_divisor = 10 //We teleport past the armor
+	armor_penetration = 100 //We teleport past the armor
 
 	//spawn_blacklisted = TRUE
 	var/change_tele_to_mob = 25

--- a/code/modules/mob/living/carbon/superior_animal/roach/types/emp.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/types/emp.dm
@@ -10,7 +10,7 @@
 	deathmessage = "pulses violently as it dies!"
 	melee_damage_lower = 12
 	melee_damage_upper = 15 //Rare
-	armor_divisor = 4
+	armor_penetration = 4
 
 	mob_size = MOB_MEDIUM
 	meat_type = /obj/item/reagent_containers/food/snacks/meat/roachmeat/elektromagnetisch

--- a/code/modules/mob/living/carbon/superior_animal/roach/types/fuhrer.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/types/fuhrer.dm
@@ -23,7 +23,7 @@
 	flash_resistances = 5 //half stuns by flash, so we can still get up and be in the fight!
 
 	armor = list(melee = 3, bullet = 1, energy = 0, bomb = 5, bio = 20, rad = 0, agony = 0)
-	armor_divisor = 1.25
+	armor_penetration = 2
 
 	meat_type = /obj/item/reagent_containers/food/snacks/meat/roachmeat/fuhrer
 	meat_amount = 6

--- a/code/modules/mob/living/carbon/superior_animal/roach/types/glowing.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/types/glowing.dm
@@ -22,7 +22,7 @@
 	knockdown_odds = 3 //Well we still can knockdown we dont tend to over other affects
 	melee_damage_lower = 5
 	melee_damage_upper = 7 //Weaker than hunter
-	armor_divisor = 1
+	armor_penetration = 0
 
 /mob/living/carbon/superior_animal/roach/glowing/UnarmedAttack(var/atom/A, var/proximity)
 	. = ..()

--- a/code/modules/mob/living/carbon/superior_animal/roach/types/hunter.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/types/hunter.dm
@@ -16,4 +16,4 @@
 
 	meat_type = /obj/item/reagent_containers/food/snacks/meat/roachmeat/jager
 	meat_amount = 3
-	armor_divisor = 1.1
+	armor_penetration = 2

--- a/code/modules/mob/living/carbon/superior_animal/roach/types/kaiser.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/types/kaiser.dm
@@ -30,7 +30,7 @@ Has ability of every roach.
 	mouse_opacity = MOUSE_OPACITY_OPAQUE // Easier to click on in melee, they're giant targets anyway
 
 	flash_resistances = 9.9 // were not fully flash proof but almost...
-	armor_divisor = 4
+	armor_penetration = 8
 
 	var/distress_call_stage = 3
 

--- a/code/modules/mob/living/carbon/superior_animal/roach/types/nanites.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/types/nanites.dm
@@ -22,7 +22,7 @@
 
 	min_air_pressure = 0
 	min_bodytemperature = 0
-	armor_divisor = 2
+	armor_penetration = 2
 	never_stimulate_air = TRUE
 
 	var/list/nanite_swarms = list()

--- a/code/modules/mob/living/carbon/superior_animal/roach/types/tank.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/types/tank.dm
@@ -14,7 +14,7 @@
 	get_stat_modifier = TRUE //we're big boys, we get a little mod as a treat.
 
 	armor = list(melee = 3, bullet = 1, energy = 0, bomb = 5, bio = 20, rad = 0, agony = 0)
-	armor_divisor = 1.2
+	armor_penetration = 0
 
 // Panzers won't slip over on water or soap.
 /mob/living/carbon/superior_animal/roach/tank/slip(slipped_on,stun_duration=8)

--- a/code/modules/mob/living/carbon/superior_animal/roach/types/tazntz.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/types/tazntz.dm
@@ -15,7 +15,7 @@
 	melee_damage_upper = 12
 
 	armor = list(melee = 3, bullet = 2, energy = 1, bomb = 5, bio = 20, rad = 0, agony = 0)
-	armor_divisor = 1.3
+	armor_penetration = 2
 
 // frogs dont slip over on water or soap.
 /mob/living/carbon/superior_animal/roach/tazntz/slip(slipped_on,stun_duration=8)

--- a/code/modules/mob/living/carbon/superior_animal/roach/types/toxic.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/types/toxic.dm
@@ -13,7 +13,7 @@
 	knockdown_odds = 3
 	melee_damage_lower = 3
 	melee_damage_upper = 7 //Weaker than hunter
-	armor_divisor = 1.3
+	armor_penetration = 0
 
 /mob/living/carbon/superior_animal/roach/toxic/UnarmedAttack(atom/A, proximity)
 	. = ..()

--- a/code/modules/mob/living/carbon/superior_animal/termite/termite.dm
+++ b/code/modules/mob/living/carbon/superior_animal/termite/termite.dm
@@ -27,7 +27,7 @@ GLOBAL_LIST_INIT(termites_special, list(/mob/living/carbon/superior_animal/termi
 
 	fleshcolor = "#7C90B8"
 	bloodcolor = "#7C90B8"
-	armor_divisor = 1
+	armor_penetration = 1
 
 	destroy_surroundings = TRUE
 	friendly_to_colony = FALSE
@@ -255,7 +255,7 @@ GLOBAL_LIST_INIT(termites_special, list(/mob/living/carbon/superior_animal/termi
 	icon = 'icons/mob/mobs-termite.dmi' // Sprites made by Polyushko#0323
 	icon_state = "koroleva_termite"
 	icon_dead = "koroleva_gore"
-	armor_divisor = 1.5
+	armor_penetration = 2
 	get_stat_modifier =  TRUE
 
 //Health related variables
@@ -287,7 +287,7 @@ GLOBAL_LIST_INIT(termites_special, list(/mob/living/carbon/superior_animal/termi
 	projectiletype = /obj/item/projectile/bullet/spear
 	contaminant_immunity = TRUE
 	get_stat_modifier =  TRUE
-	armor_divisor = 1.5
+	armor_penetration = 2
 
 //Health related variables
 	maxHealth = TERMITE_HEALTH_HIGH

--- a/code/modules/mob/living/carbon/superior_animal/termite/termite_no_despawn.dm
+++ b/code/modules/mob/living/carbon/superior_animal/termite/termite_no_despawn.dm
@@ -17,7 +17,7 @@
 	faction = "wurm"
 	fire_verb = "spits"
 	see_in_dark = 10
-	armor_divisor = 1.1
+	armor_penetration = 1
 	density = 0 // Prevents friendly fire between themselves, projectiles will go over them, making them also harder to target.
 
 	fleshcolor = "#7C90B8"
@@ -190,7 +190,7 @@
 	icon = 'icons/mob/mobs-termite.dmi' // Sprites made by Polyushko#0323
 	icon_state = "koroleva_termite"
 	icon_dead = "koroleva_gore"
-	armor_divisor = 1.3
+	armor_penetration = 1
 	get_stat_modifier =  TRUE
 	inherent_mutations = list(MUTATION_DEAF, MUTATION_RAND_UNSTABLE, MUTATION_GIGANTISM, MUTATION_PROT_MILK, MUTATION_TERMITE_FRIEND)
 
@@ -223,7 +223,7 @@
 	projectiletype = /obj/item/projectile/bullet/spear
 	contaminant_immunity = TRUE
 	get_stat_modifier =  TRUE
-	armor_divisor = 1.5
+	armor_penetration = 2
 	inherent_mutations = list(MUTATION_DEAF, MUTATION_RAND_UNSTABLE, MUTATION_GIGANTISM, MUTATION_SCREAMING)
 
 //Health related variables

--- a/code/modules/mob/living/carbon/superior_animal/vox/thrown_items.dm
+++ b/code/modules/mob/living/carbon/superior_animal/vox/thrown_items.dm
@@ -2,7 +2,7 @@
 	name = "sharp stone"
 	damage_types = list(BRUTE = 16)
 	agony = 12
-	armor_divisor = 1
+	armor_penetration = 1
 	step_delay = 1.15
 	check_armour = ARMOR_MELEE
 	can_ricochet = FALSE
@@ -15,7 +15,7 @@
 	name = "rock fragements"
 	damage_types = list(BRUTE = 24) //Same as a .40
 	agony = 15
-	armor_divisor = 1.25 //primitive.
+	armor_penetration = 2 //primitive.
 	step_delay = 1
 	check_armour = ARMOR_MELEE
 	can_ricochet = FALSE

--- a/code/modules/mob/living/carbon/superior_animal/vox/types/vox_types.dm
+++ b/code/modules/mob/living/carbon/superior_animal/vox/types/vox_types.dm
@@ -47,7 +47,7 @@
 	armor = list(melee = 8, bullet = 5, energy = 0, bomb = 50, bio = 0, rad = 0)
 
 	ranged = FALSE
-	armor_divisor = 1.25
+	armor_penetration = 2
 
 /mob/living/carbon/superior_animal/vox/hider
 	name = "Inuwa kisa"
@@ -94,7 +94,7 @@
 
 	maxHealth = 90 * VOXBIRD_HEALTH_MOD
 	health = 90 * VOXBIRD_HEALTH_MOD
-	armor_divisor = 1.25
+	armor_penetration = 2
 
 /mob/living/carbon/superior_animal/vox/weak
 	name = "Yaro mafarauci"
@@ -122,7 +122,7 @@
 	melee_damage_upper = 35
 
 	knock_over_odds = 25
-	armor_divisor = 1.25
+	armor_penetration = 2
 
 /mob/living/carbon/superior_animal/vox/scout
 	name = "karfe kafafu"

--- a/code/modules/mob/living/carbon/superior_animal/vox/vox.dm
+++ b/code/modules/mob/living/carbon/superior_animal/vox/vox.dm
@@ -29,7 +29,7 @@
 	get_stat_modifier = TRUE
 
 	melee_sharp = TRUE //Claws
-	armor_divisor = 1.25
+	armor_penetration = 2
 
 	allowed_stat_modifiers = list(
 		/datum/stat_modifier/mob/living/carbon/superior_animal/armor/mult/positive/low = 15,

--- a/code/modules/mob/living/carbon/superior_animal/xenomorph/drone.dm
+++ b/code/modules/mob/living/carbon/superior_animal/xenomorph/drone.dm
@@ -17,7 +17,7 @@ var/datum/xenomorph/xenomorph_ai
 	mob_size = MOB_LARGE
 	viewRange = 8
 	armor = list(melee = 7, bullet = 7, energy = 1, bomb = 30, bio = 100, rad = 100)
-	armor_divisor = 1.25
+	armor_penetration = 1
 
 	maxHealth = 30
 	health = 30
@@ -87,7 +87,7 @@ var/datum/xenomorph/xenomorph_ai
 
 
 	melee_sharp = TRUE //claws
-	armor_divisor = 1.25
+	armor_penetration = 1
 
 
 /mob/living/carbon/superior_animal/xenomorph/slip(slipped_on,stun_duration=8)

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -7,7 +7,7 @@
 	Returns
 	standard 0 if fail
 */
-/mob/living/proc/apply_damage(damage = 0, damagetype = BRUTE, def_zone = null, armor_divisor = 1, wounding_multiplier = 1, sharp = FALSE, edge = FALSE, used_weapon = null) // After melee rebalance set wounding_multiplier to 0 to activate melee wounding level determination
+/mob/living/proc/apply_damage(damage = 0, damagetype = BRUTE, def_zone = null, armor_penetration = 1, wounding_multiplier = 1, sharp = FALSE, edge = FALSE, used_weapon = null) // After melee rebalance set wounding_multiplier to 0 to activate melee wounding level determination
 	activate_ai()
 	switch(damagetype)
 		if(BRUTE)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -16,7 +16,7 @@
 	else
 		show_message(msg1, 1)
 
-/mob/living/proc/damage_through_armor(damage = 0, damagetype = BRUTE, def_zone, attack_flag = ARMOR_MELEE, armor_penetration = 0, used_weapon, sharp = FALSE, edge = FALSE, wounding_multiplier, list/dmg_types = list(), return_continuation = FALSE, dir_mult = 1)
+/mob/living/proc/damage_through_armor(damage = 0, damagetype = BRUTE, def_zone, attack_flag = ARMOR_MELEE, armor_penetration = 0, armor_maximum, used_weapon, sharp = FALSE, edge = FALSE, wounding_multiplier, list/dmg_types = list(), return_continuation = FALSE, dir_mult = 1)
 	if(damage) // If damage is defined, we add it to the list
 		if(!dmg_types[damagetype])
 			dmg_types += damagetype
@@ -60,11 +60,13 @@
 
 
 	// Determine DR and ADR, armour divisor reduces it
-	var/armor = min(0, (-getarmor(def_zone, attack_flag) + armor_penetration))
+	var/armor = min(armor_maximum, (-getarmor(def_zone, attack_flag) + armor_penetration))
 	if(!(attack_flag in list(ARMOR_MELEE, ARMOR_BULLET, ARMOR_ENERGY))) // Making sure BIO and other armor types are handled correctly
 		armor /= 5
-	var/ablative_armor = min(0, (-getarmorablative(def_zone, attack_flag) + armor_penetration))
-
+	var/ablative_armor = min(armor_maximum, (-getarmorablative(def_zone, attack_flag) + armor_penetration))
+// Damage calculation for QoL purposes.
+// ((Base Projectile Damage * Weapon Damage Projectile Multiplier) + min(armor_maximum, (-Armor + Penetration Power))) * Wound Scale = Result Damage
+// Results in clear, flat damage reduction and flat armor pen.
 	var/remaining_armor = armor
 	var/remaining_ablative = ablative_armor
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -96,7 +96,7 @@
 				var/effective_damage = damage - guaranteed_damage_red
 
 				if(damagetype == HALLOSS)
-					effective_damage =  max(0,round(effective_damage - mob_agony_armor))
+					effective_damage =  max(0,round(effective_damage - mob_agony_armor) / 2) // Mobs only take half halloss damage. They're mutant beasts!
 
 			if(!(dmg_type == HALLOSS)) // Determine pain from impact
 				adjustHalLoss(used_armor * (wounding_multiplier ? wounding_multiplier : 1) * ARMOR_HALLOS_COEFFICIENT * max(0.5, (get_specific_organ_efficiency(OP_NERVE, def_zone) / 100)))

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -65,7 +65,7 @@
 		armor /= 5
 	var/ablative_armor = max(armor_maximum, (getarmorablative(def_zone, attack_flag) - armor_penetration))
 // Damage calculation for QoL purposes.
-// ((Base Projectile Damage * Weapon Damage Projectile Multiplier) + min(armor_maximum, (-Armor + Penetration Power))) * Wound Scale = Result Damage
+// ((Base Projectile Damage * Weapon Damage Projectile Multiplier) - max(armor_maximum, (Armor - Penetration Power))) * Wound Scale = Result Damage
 // Results in clear, flat damage reduction and flat armor pen.
 	var/remaining_armor = armor
 	var/remaining_ablative = ablative_armor

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -16,14 +16,14 @@
 	else
 		show_message(msg1, 1)
 
-/mob/living/proc/damage_through_armor(damage = 0, damagetype = BRUTE, def_zone, attack_flag = ARMOR_MELEE, armor_divisor = 0, used_weapon, sharp = FALSE, edge = FALSE, wounding_multiplier, list/dmg_types = list(), return_continuation = FALSE, dir_mult = 1)
+/mob/living/proc/damage_through_armor(damage = 0, damagetype = BRUTE, def_zone, attack_flag = ARMOR_MELEE, armor_penetration = 0, used_weapon, sharp = FALSE, edge = FALSE, wounding_multiplier, list/dmg_types = list(), return_continuation = FALSE, dir_mult = 1)
 	if(damage) // If damage is defined, we add it to the list
 		if(!dmg_types[damagetype])
 			dmg_types += damagetype
 		dmg_types[damagetype] += damage
 
-	if(armor_divisor <= 0)
-		armor_divisor = 0.001
+	if(armor_penetration <= 0)
+		armor_penetration = 0.001
 		log_debug("[used_weapon] applied damage to [name] with a nonpositive armor divisor")
 
 	var/total_dmg = 0
@@ -60,10 +60,10 @@
 
 
 	// Determine DR and ADR, armour divisor reduces it
-	var/armor = getarmor(def_zone, attack_flag) / armor_divisor
+	var/armor = min(0, (-getarmor(def_zone, attack_flag) + armor_penetration))
 	if(!(attack_flag in list(ARMOR_MELEE, ARMOR_BULLET, ARMOR_ENERGY))) // Making sure BIO and other armor types are handled correctly
 		armor /= 5
-	var/ablative_armor = getarmorablative(def_zone, attack_flag) / armor_divisor
+	var/ablative_armor = min(0, (-getarmorablative(def_zone, attack_flag) + armor_penetration))
 
 	var/remaining_armor = armor
 	var/remaining_ablative = ablative_armor
@@ -75,14 +75,14 @@
 
 			if(dmg_type in list(BRUTE, BURN, TOX, BLAST)) // Some damage types do not help penetrate armor
 				if(remaining_armor)
-					var/dmg_armor_difference = dmg - remaining_armor
+					var/dmg_armor_difference = dmg + remaining_armor
 					var/is_difference_positive = dmg_armor_difference > 0
 					used_armor += is_difference_positive ? dmg - dmg_armor_difference : dmg
 					remaining_armor = is_difference_positive ? 0 : -dmg_armor_difference
 					dmg = is_difference_positive ? dmg_armor_difference : 0
 				if(remaining_ablative && dmg)
 					var/ablative_difference
-					ablative_difference = dmg - remaining_ablative
+					ablative_difference = dmg + remaining_ablative
 					var/is_difference_positive = ablative_difference > 0
 					used_armor += is_difference_positive ? dmg - ablative_difference : dmg
 					remaining_ablative = is_difference_positive ? 0 : -ablative_difference
@@ -107,7 +107,7 @@
 
 				if(dmg_type == HALLOSS && ishuman(src)) //We already did this for mobs
 					dmg = round(dmg * clamp((get_specific_organ_efficiency(OP_NERVE, def_zone) / 100), 0.5, 1.5))
-					var/pain_armor = max(0, (src.getarmor(def_zone, "bullet") +  src.getarmor(def_zone, "melee") / armor_divisor))//All brute over-pen checks bullet rather then melee for simple mobs to keep melee viable
+					var/pain_armor = max(0, (src.getarmor(def_zone, "bullet") +  src.getarmor(def_zone, "melee") / armor_penetration))//All brute over-pen checks bullet rather then melee for simple mobs to keep melee viable
 					var/pain_no_matter_what = (dmg * 0.15) //we deal 15% of are pain, this is to stop rubbers being *completely* uses with basic armor - Its not perfect in melee
 					dmg = max(pain_no_matter_what, (dmg - pain_armor))
 					if(ishuman(src))
@@ -137,7 +137,7 @@
 						armor_message(SPAN_NOTICE("[src] armor deflected the strike!"), // No cut (strike), only bash
 										SPAN_NOTICE("Your armor deflects the strike!"))
 
-				apply_damage(dmg, dmg_type, def_zone, armor_divisor, wounding_multiplier, sharp, edge, used_weapon)
+				apply_damage(dmg, dmg_type, def_zone, armor_penetration, wounding_multiplier, sharp, edge, used_weapon)
 				if(ishuman(src) && def_zone && dmg >= 20)
 					var/mob/living/carbon/human/H = src
 					var/obj/item/organ/external/o = H.get_organ(def_zone)
@@ -168,7 +168,7 @@
 
 	// Deal damage to ablative armour based on how much was used, we multiply armour divisor back so high AP doesn't decrease damage dealt to ADR
 	if(ablative_armor)
-		damageablative(def_zone, (ablative_armor - remaining_ablative) * armor_divisor)
+		damageablative(def_zone, (ablative_armor - remaining_ablative) * armor_penetration)
 
 	//If we have a grab in our hands and get hit with melee damage type, there is a chance we lower our grab's state
 	if(attack_flag == ARMOR_MELEE && ishuman(src) && isitem(used_weapon))
@@ -250,7 +250,7 @@
 				dmult += P.supereffective_mult
 			damage *= dmult
 		hit_impact(P.get_structure_damage(), hit_dir)
-		return damage_through_armor(def_zone = def_zone_hit, attack_flag = P.check_armour, armor_divisor = P.armor_divisor, used_weapon = P, sharp = is_sharp(P), edge = has_edge(P), wounding_multiplier = P.wounding_mult, dmg_types = P.damage_types, return_continuation = TRUE)
+		return damage_through_armor(def_zone = def_zone_hit, attack_flag = P.check_armour, armor_penetration = P.armor_penetration, used_weapon = P, sharp = is_sharp(P), edge = has_edge(P), wounding_multiplier = P.wounding_mult, dmg_types = P.damage_types, return_continuation = TRUE)
 
 	return PROJECTILE_CONTINUE
 
@@ -310,7 +310,7 @@
 //		effective_force *= 2
 
 	//Apply weapon damage
-	if (damage_through_armor(effective_force, I.damtype, hit_zone, ARMOR_MELEE, I.armor_divisor, used_weapon = I, sharp = is_sharp(I), edge = has_edge(I)))
+	if (damage_through_armor(effective_force, I.damtype, hit_zone, ARMOR_MELEE, I.armor_penetration, used_weapon = I, sharp = is_sharp(I), edge = has_edge(I)))
 		return TRUE
 	else
 		return FALSE
@@ -336,7 +336,7 @@
 
 		src.visible_message(SPAN_WARNING("[src] has been hit by [O]."))
 
-		damage_through_armor(throw_damage, dtype, null, ARMOR_MELEE, O.armor_divisor, used_weapon = O, sharp = is_sharp(O), edge = has_edge(O))
+		damage_through_armor(throw_damage, dtype, null, ARMOR_MELEE, O.armor_penetration, used_weapon = O, sharp = is_sharp(O), edge = has_edge(O))
 
 		O.throwing = 0		//it hit, so stop moving
 
@@ -413,11 +413,11 @@
 
 	if(!damage || !istype(user))
 		return
-	
+
 	var/used_divisor = 1
 	if(isliving(user))
 		var/mob/living/L = user
-		used_divisor = L.armor_divisor
+		used_divisor = L.armor_penetration
 	var/attack_BP = BP_CHEST
 	if(prob(20))
 		attack_BP = pick(list(BP_L_LEG, BP_R_LEG, BP_R_ARM, BP_L_ARM, BP_GROIN, BP_HEAD))

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -16,7 +16,7 @@
 	else
 		show_message(msg1, 1)
 
-/mob/living/proc/damage_through_armor(damage = 0, damagetype = BRUTE, def_zone, attack_flag = ARMOR_MELEE, armor_penetration = 0, armor_maximum, used_weapon, sharp = FALSE, edge = FALSE, wounding_multiplier, list/dmg_types = list(), return_continuation = FALSE, dir_mult = 1)
+/mob/living/proc/damage_through_armor(damage = 0, damagetype = BRUTE, def_zone, attack_flag = ARMOR_MELEE, armor_penetration = 0, used_weapon, sharp = FALSE, edge = FALSE, wounding_multiplier, list/dmg_types = list(), return_continuation = FALSE, armor_maximum)
 	if(damage) // If damage is defined, we add it to the list
 		if(!dmg_types[damagetype])
 			dmg_types += damagetype
@@ -60,10 +60,10 @@
 
 
 	// Determine DR and ADR, armour divisor reduces it
-	var/armor = min(armor_maximum, (-getarmor(def_zone, attack_flag) + armor_penetration))
+	var/armor = max(armor_maximum, (getarmor(def_zone, attack_flag) - armor_penetration))
 	if(!(attack_flag in list(ARMOR_MELEE, ARMOR_BULLET, ARMOR_ENERGY))) // Making sure BIO and other armor types are handled correctly
 		armor /= 5
-	var/ablative_armor = min(armor_maximum, (-getarmorablative(def_zone, attack_flag) + armor_penetration))
+	var/ablative_armor = max(armor_maximum, (getarmorablative(def_zone, attack_flag) - armor_penetration))
 // Damage calculation for QoL purposes.
 // ((Base Projectile Damage * Weapon Damage Projectile Multiplier) + min(armor_maximum, (-Armor + Penetration Power))) * Wound Scale = Result Damage
 // Results in clear, flat damage reduction and flat armor pen.
@@ -77,14 +77,14 @@
 
 			if(dmg_type in list(BRUTE, BURN, TOX, BLAST)) // Some damage types do not help penetrate armor
 				if(remaining_armor)
-					var/dmg_armor_difference = dmg + remaining_armor
+					var/dmg_armor_difference = dmg - remaining_armor
 					var/is_difference_positive = dmg_armor_difference > 0
 					used_armor += is_difference_positive ? dmg - dmg_armor_difference : dmg
 					remaining_armor = is_difference_positive ? 0 : -dmg_armor_difference
 					dmg = is_difference_positive ? dmg_armor_difference : 0
 				if(remaining_ablative && dmg)
 					var/ablative_difference
-					ablative_difference = dmg + remaining_ablative
+					ablative_difference = dmg - remaining_ablative
 					var/is_difference_positive = ablative_difference > 0
 					used_armor += is_difference_positive ? dmg - ablative_difference : dmg
 					remaining_ablative = is_difference_positive ? 0 : -ablative_difference

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -34,9 +34,9 @@
 	/// The buildmode holders this mob is currently selected by.
 	var/list/obj/effect/bmode/buildholder/selected_by = list()
 
-	var/armor_divisor = 1 //Used for generic attacks
-	var/projectile_armor_divisor_adjustment = 0
-	var/projectile_armor_divisor_mult = 1
+	var/armor_penetration = 1 //Used for generic attacks
+	var/projectile_armor_penetration_adjustment = 0
+	var/projectile_armor_penetration_mult = 1
 
 	//Damage related vars, NOTE: THESE SHOULD ONLY BE MODIFIED BY PROCS
 	var/bruteloss = 0.0	//Brutal damage caused by brute force (punching, being clubbed by a toolbox ect... this also accounts for pressure damage)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -557,7 +557,7 @@
 			var/mob/living/carbon/human/firer = Proj.firer
 			chance -= firer.stats.getStat(STAT_VIG, FALSE) / 5
 		var/obj/item/projectile/bullet/B = Proj
-		chance = max((chance / B.armor_divisor), 0)
+		chance = max((chance / B.armor_penetration), 0)
 		if (!(Proj.testing))
 			if(B.starting && prob(chance)) // disregard this for test because its luck based
 				visible_message(SPAN_DANGER("\The [Proj.name] ricochets off [src]\'s armour!"))

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -415,7 +415,7 @@
 			dmult += Proj.supereffective_mult
 		damage *= dmult
 		if (!(Proj.testing))
-			return damage_through_armor(damage, def_zone, attack_flag = Proj.check_armour, armor_divisor = Proj.armor_divisor, used_weapon = Proj, sharp = is_sharp(Proj), edge = has_edge(Proj), wounding_multiplier = Proj.wounding_mult, dmg_types = Proj.damage_types, return_continuation = TRUE)
+			return damage_through_armor(damage, def_zone, attack_flag = Proj.check_armour, armor_penetration = Proj.armor_penetration, used_weapon = Proj, sharp = is_sharp(Proj), edge = has_edge(Proj), wounding_multiplier = Proj.wounding_mult, dmg_types = Proj.damage_types, return_continuation = TRUE)
 	return FALSE
 
 /mob/living/simple_animal/rejuvenate()

--- a/code/modules/mob/mob_grab_specials.dm
+++ b/code/modules/mob/mob_grab_specials.dm
@@ -318,7 +318,7 @@
 		sleep(1)
 
 	target.throw_at(get_edge_target_turf(target, dir), 7, 2)//this is very fast, and very painful for any obstacle involved
-	target.damage_through_armor(damage, HALLOSS, armor_divisor = 2)
+	target.damage_through_armor(damage, HALLOSS, armor_penetration = 2)
 //	attacker.regen_slickness(0.4)
 
 	//admin messaging

--- a/code/modules/organs/external/damage.dm
+++ b/code/modules/organs/external/damage.dm
@@ -5,7 +5,7 @@
 /obj/item/organ/external/proc/is_damageable(additional_damage = 0)
 	return (vital || brute_dam + burn_dam + additional_damage < max_damage)
 
-/obj/item/organ/external/take_damage(amount, damage_type, armor_divisor = 1, wounding_multiplier = 1, sharp, edge, used_weapon = null, list/forbidden_limbs = list(), silent)
+/obj/item/organ/external/take_damage(amount, damage_type, armor_penetration = 1, wounding_multiplier = 1, sharp, edge, used_weapon = null, list/forbidden_limbs = list(), silent)
 	var/prev_brute = brute_dam	//We'll record how much damage the limb already had, before we apply the damage from this incoming hit
 	var/prev_burn = burn_dam
 
@@ -28,9 +28,9 @@
 		var/transferred_damage_amount
 		switch(damage_type)
 			if(BRUTE)
-				transferred_damage_amount = amount - (max_damage - brute_dam) / armor_divisor / 2
+				transferred_damage_amount = amount - (max_damage - brute_dam) / armor_penetration / 2
 			if(BURN)
-				transferred_damage_amount = amount - (max_damage - burn_dam) / armor_divisor / 2
+				transferred_damage_amount = amount - (max_damage - burn_dam) / armor_penetration / 2
 			if(HALLOSS)
 				transferred_damage_amount = 0
 			else

--- a/code/modules/organs/external/subtypes/standard.dm
+++ b/code/modules/organs/external/subtypes/standard.dm
@@ -19,7 +19,7 @@
 			owner.update_hair()
 	..()
 
-/obj/item/organ/external/head/take_damage(amount, damage_type, armor_divisor = max(1, armor_divisor), wounding_multiplier = 1, sharp, edge, used_weapon = null, list/forbidden_limbs = list(), silent)
+/obj/item/organ/external/head/take_damage(amount, damage_type, armor_penetration = max(1, armor_penetration), wounding_multiplier = 1, sharp, edge, used_weapon = null, list/forbidden_limbs = list(), silent)
 	. = ..()
 	if(. && !disfigured)
 		if(amount > 25)

--- a/code/modules/projectiles/ammunition/bullets.dm
+++ b/code/modules/projectiles/ammunition/bullets.dm
@@ -931,7 +931,7 @@
 	w_class = ITEM_SIZE_SMALL
 	caliber = CAL_ARROW
 	force = WEAPON_FORCE_NORMAL
-	armor_divisor = ARMOR_PEN_GRAZING
+	armor_penetration = ARMOR_PEN_GRAZING
 	projectile_type = /obj/item/projectile/bullet/reusable/arrow
 	matter = list(MATERIAL_STEEL = 0.5, MATERIAL_WOOD = 0.5, MATERIAL_PLASTIC= 0.5)
 	maxamount = 3
@@ -962,7 +962,7 @@
 	name = "broadhead arrow"
 	icon_state = "arrow-broad"
 	force = WEAPON_FORCE_PAINFUL
-	armor_divisor = 1
+	armor_penetration = 1
 	desc = "A good-quality handmade arrow, with a metal head and plastic fletching. This one has quite a broad head, capable of causing severe damage to unarmored targets, but reducing its ability to penetrate armor."
 	projectile_type = /obj/item/projectile/bullet/reusable/arrow/broadhead
 
@@ -970,7 +970,7 @@
 	name = "serrated arrow"
 	icon_state = "arrow-serrated"
 	force = WEAPON_FORCE_PAINFUL
-	armor_divisor = 1
+	armor_penetration = 1
 	desc = "A good-quality handmade aerodinamic arrow, with a metal head and plastic fletching. This one has wicked sharp serrated blades along its head, letting it stick in wounds easily, penetrating thick hide and armor alike at fast speeds."
 	projectile_type = /obj/item/projectile/bullet/reusable/arrow/serrated
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -1208,7 +1208,7 @@ For the sake of consistency, I suggest always rounding up on even values when ap
 	var/list/melee_stats = list()
 
 	melee_stats += list(list("name" = "Melee Capabilities", "type" = "ProgressBar", "value" = force, "max" = initial(force) * 10))
-	melee_stats += list(list( "name" = "Armor Divisor", "type" = "AnimatedNumber", "value" = armor_penetration, "max" = 10))
+	melee_stats += list(list( "name" = "Armor Penetration", "type" = "AnimatedNumber", "value" = armor_penetration, "max" = 10))
 
 	stats["Physical Details"] = melee_stats
 
@@ -1277,7 +1277,7 @@ For the sake of consistency, I suggest always rounding up on even values when ap
 
 	data += list(list("name" = "Projectile Type", "type" = "String", "value" = P.name))
 	data += list(list("name" = "Overall Damage", "type" = "String", "value" = (P.get_total_damage() * damage_multiplier) + get_total_damage_adjust()))
-	data += list(list("name" = "Armor Divisor", "type" = "String", "value" = P.armor_penetration * penetration_multiplier))
+	data += list(list("name" = "Armor Penetration", "type" = "String", "value" = P.armor_penetration * penetration_multiplier))
 	data += list(list("name" = "Overall Pain", "type" = "String", "value" = (P.get_pain_damage()) * proj_agony_multiplier))
 	data += list(list("name" = "Wound Scale", "type" = "String", "value" = P.wounding_mult))
 	data += list(list("name" = "Recoil Multiplier", "type" = "String", "value" = P.recoil))

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -1208,7 +1208,7 @@ For the sake of consistency, I suggest always rounding up on even values when ap
 	var/list/melee_stats = list()
 
 	melee_stats += list(list("name" = "Melee Capabilities", "type" = "ProgressBar", "value" = force, "max" = initial(force) * 10))
-	melee_stats += list(list( "name" = "Armor Divisor", "type" = "AnimatedNumber", "value" = armor_divisor, "max" = 10))
+	melee_stats += list(list( "name" = "Armor Divisor", "type" = "AnimatedNumber", "value" = armor_penetration, "max" = 10))
 
 	stats["Physical Details"] = melee_stats
 
@@ -1277,7 +1277,7 @@ For the sake of consistency, I suggest always rounding up on even values when ap
 
 	data += list(list("name" = "Projectile Type", "type" = "String", "value" = P.name))
 	data += list(list("name" = "Overall Damage", "type" = "String", "value" = (P.get_total_damage() * damage_multiplier) + get_total_damage_adjust()))
-	data += list(list("name" = "Armor Divisor", "type" = "String", "value" = P.armor_divisor * penetration_multiplier))
+	data += list(list("name" = "Armor Divisor", "type" = "String", "value" = P.armor_penetration * penetration_multiplier))
 	data += list(list("name" = "Overall Pain", "type" = "String", "value" = (P.get_pain_damage()) * proj_agony_multiplier))
 	data += list(list("name" = "Wound Scale", "type" = "String", "value" = P.wounding_mult))
 	data += list(list("name" = "Recoil Multiplier", "type" = "String", "value" = P.recoil))
@@ -1290,11 +1290,11 @@ For the sake of consistency, I suggest always rounding up on even values when ap
 	var/list/data = list()
 	data["projectile_name"] = P.name
 	data["projectile_damage"] = (P.get_total_damage() * damage_multiplier) + get_total_damage_adjust()
-	data["projectile_AP"] = P.armor_divisor + penetration_multiplier
+	data["projectile_AP"] = P.armor_penetration + penetration_multiplier
 	data["projectile_WOUND"] = P.wounding_mult
 	data["unarmoured_damage"] = min(0, ((P.get_total_damage() * damage_multiplier) + get_total_damage_adjust()) * P.wounding_mult)
-	data["armoured_damage_10"] = min(0, (((P.get_total_damage() * damage_multiplier) + get_total_damage_adjust()) - (10 / (P.armor_divisor + penetration_multiplier))) * P.wounding_mult)
-	data["armoured_damage_15"] = min(0, (((P.get_total_damage() * damage_multiplier) + get_total_damage_adjust()) - (15 / (P.armor_divisor + penetration_multiplier))) * P.wounding_mult)
+	data["armoured_damage_10"] = min(0, (((P.get_total_damage() * damage_multiplier) + get_total_damage_adjust()) - (10 / (P.armor_penetration + penetration_multiplier))) * P.wounding_mult)
+	data["armoured_damage_15"] = min(0, (((P.get_total_damage() * damage_multiplier) + get_total_damage_adjust()) - (15 / (P.armor_penetration + penetration_multiplier))) * P.wounding_mult)
 	data["projectile_recoil"] = P.recoil
 	qdel(P)
 	return data
@@ -1326,7 +1326,7 @@ For the sake of consistency, I suggest always rounding up on even values when ap
 	vision_flags = initial(vision_flags)
 	see_invisible_gun = initial(see_invisible_gun)
 	force = initial(force)
-	armor_divisor = initial(armor_divisor)
+	armor_penetration = initial(armor_penetration)
 	sharp = initial(sharp)
 	attack_verb = list("struck", "hit", "bashed")
 	auto_eject = initial(auto_eject) //SoJ edit

--- a/code/modules/projectiles/guns/energy/laser/concilium.dm
+++ b/code/modules/projectiles/guns/energy/laser/concilium.dm
@@ -20,7 +20,7 @@
 	slowdown_hold = 1 //heavy wood stock. Stupidly chonky
 	suitable_cell = /obj/item/cell/large
 	damage_multiplier = 1.2 //Kinda bad beam inside but can be upgraded to be a normal laser lmg!
-	armor_divisor = 0.1
+	armor_penetration = 0
 	init_offset = 3
 	price_tag = 2000
 	gun_tags = list(GUN_LASER, GUN_ENERGY)

--- a/code/modules/projectiles/guns/energy/laser/lasercore.dm
+++ b/code/modules/projectiles/guns/energy/laser/lasercore.dm
@@ -84,7 +84,7 @@
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_STEEL = 4, MATERIAL_WOOD = 12, MATERIAL_SILVER = 15, MATERIAL_GOLD = 4, MATERIAL_DIAMOND = 3) //steal the COs laser for copper wire.
 	extra_bulk = 15 //A bit more bulk than an unfolded laser-core.
 	damage_multiplier = 1.1 //essentially the same bonus you get from
-	armor_divisor = 0.2
+	armor_penetration = 0
 	zoom_factors = list(0.4)
 	extra_damage_mult_scoped = 0.2
 	max_upgrades = 3 //we're already pretty beefy.

--- a/code/modules/projectiles/guns/energy/plasma/excubitor.dm
+++ b/code/modules/projectiles/guns/energy/plasma/excubitor.dm
@@ -13,7 +13,7 @@
 	suitable_cell = /obj/item/cell/medium/neotheology
 	projectile_type = /obj/item/projectile/plasma/light
 	force = WEAPON_FORCE_BRUTAL
-	armor_divisor = ARMOR_PEN_MASSIVE
+	armor_penetration = ARMOR_PEN_MASSIVE
 	fire_delay = 10
 	charge_cost = 60 // 10 shots out of a 600M
 	init_recoil = HANDGUN_RECOIL(1)

--- a/code/modules/projectiles/guns/matter/launcher/books.dm
+++ b/code/modules/projectiles/guns/matter/launcher/books.dm
@@ -45,7 +45,7 @@
 	//Theirs better weapons then this!
 	fire_sound = 'sound/weapons/magical.ogg'
 	force = WEAPON_FORCE_ROBUST
-	armor_divisor = ARMOR_PEN_EXTREME
+	armor_penetration = ARMOR_PEN_EXTREME
 	structure_damage_factor = STRUCTURE_DAMAGE_HEAVY
 	max_stored_matter = 20
 	fire_delay = 15

--- a/code/modules/projectiles/guns/oddity_items.dm
+++ b/code/modules/projectiles/guns/oddity_items.dm
@@ -505,7 +505,7 @@
 	force = WEAPON_FORCE_HARMLESS
 	throwforce = WEAPON_FORCE_HARMLESS
 	w_class = ITEM_SIZE_NORMAL
-	armor_divisor = ARMOR_PEN_HALF
+	armor_penetration = ARMOR_PEN_DEADLY
 	structure_damage_factor = STRUCTURE_DAMAGE_DESTRUCTIVE
 	tool_qualities = list(QUALITY_HAMMERING = 20)
 	max_upgrades = 2
@@ -529,9 +529,9 @@
 	real_mod *= 0.5 //Insainly op
 
 //	message_admins("3ogre: safty_math [safty_math] safty_health [safty_health]  delay_adder [delay_adder]")
-//	message_admins("4ogre: armor_divisor [armor_divisor]")
-	armor_divisor += real_mod
-//	message_admins("5ogre: armor_divisor [armor_divisor]")
+//	message_admins("4ogre: armor_penetration [armor_penetration]")
+	armor_penetration += real_mod
+//	message_admins("5ogre: armor_penetration [armor_penetration]")
 	clickdelay_offset = delay_adder
 
 	.=..()
@@ -547,7 +547,7 @@
 	matter = list(MATERIAL_PLASTEEL = 5, MATERIAL_PLASTIC = 12)
 	force = 15 //Base level
 	backstab_damage = 15 //base is 15 but grows
-	armor_divisor = ARMOR_PEN_MASSIVE //Less do to how powerful it is
+	armor_penetration = ARMOR_PEN_MASSIVE //Less do to how powerful it is
 	throwforce = WEAPON_FORCE_ROBUST
 	price_tag = 3500
 	max_upgrades = 2
@@ -622,7 +622,7 @@
 	force = WEAPON_FORCE_DANGEROUS
 	switched_on_forcemult = 4.4 //88
 	w_class = ITEM_SIZE_NORMAL
-	armor_divisor = ARMOR_PEN_DEEP
+	armor_penetration = ARMOR_PEN_DEEP
 	switched_on_penmult = 2.5 //50
 	matter = list(MATERIAL_SILVER = 2, MATERIAL_PLASTEEL = 10, MATERIAL_PLASTIC = 3)
 	tool_qualities = list(QUALITY_SAWING = 70, QUALITY_CUTTING = 60, QUALITY_WIRE_CUTTING = 30)
@@ -708,7 +708,7 @@
 			//message_admins("2knife: speedy_dashing [speedy_dashing]")
 			if(speedy_dashing > 0)
 				//Hopefully your running around to accually use this
-				armor_divisor *= speedy_dashing
+				armor_penetration *= speedy_dashing
 				force *= speedy_dashing
 			if(tracker == target.name && give_coin)
 				coin_tracker += 1
@@ -752,7 +752,7 @@
 	item_state = "katana"
 	hitsound = 'sound/weapons/heavyslash.ogg'
 	force = WEAPON_FORCE_BRUTAL
-	armor_divisor = ARMOR_PEN_SHALLOW
+	armor_penetration = ARMOR_PEN_SHALLOW
 	price_tag = 2050
 	clickdelay_offset = 0
 	max_upgrades = 1//Already over powered.
@@ -781,7 +781,7 @@
 	icon_state = "spectral_harvester"
 	hitsound = 'sound/weapons/heavyslash.ogg'
 	force = WEAPON_FORCE_GODLIKE //88 damage but + weilding
-	armor_divisor = ARMOR_PEN_MODERATE
+	armor_penetration = ARMOR_PEN_MODERATE
 	price_tag = 2750
 	clickdelay_offset = 15 //This stacks with base
 	max_upgrades = 0 //No...
@@ -902,7 +902,7 @@
 	slowdown_hold = 0.3
 	//Its a bad weapon
 	force = WEAPON_FORCE_PAINFUL
-	armor_divisor = ARMOR_PEN_SHALLOW
+	armor_penetration = ARMOR_PEN_SHALLOW
 	has_alt_mode = FALSE
 
 /obj/item/shield/riot/mass_grave/check_shield_arc()
@@ -918,31 +918,31 @@
 		if(5)
 			armor_list = list(melee = 2, bullet = 2, energy = 2, bomb = 0, bio = 0, rad = 0)
 			force = WEAPON_FORCE_DANGEROUS
-			armor_divisor = ARMOR_PEN_MODERATE
+			armor_penetration = ARMOR_PEN_MODERATE
 			slowdown = 0.25
 			slowdown_hold = 0.25
 		if(10)
 			armor_list = list(melee = 4, bullet = 4, energy = 4, bomb = 0, bio = 0, rad = 0)
 			force = WEAPON_FORCE_ROBUST
-			armor_divisor = ARMOR_PEN_DEEP
+			armor_penetration = ARMOR_PEN_DEEP
 			slowdown = 0.20
 			slowdown_hold = 0.20
 		if(20)
 			armor_list = list(melee = 6, bullet = 6, energy = 6, bomb = 0, bio = 0, rad = 0)
 			force = WEAPON_FORCE_BRUTAL
-			armor_divisor = ARMOR_PEN_EXTREME
+			armor_penetration = ARMOR_PEN_EXTREME
 			slowdown = 0.15
 			slowdown_hold = 0.15
 		if(50)
 			armor_list = list(melee = 9, bullet = 9, energy = 9, bomb = 0, bio = 0, rad = 0)
 			force = WEAPON_FORCE_LETHAL
-			armor_divisor = ARMOR_PEN_MASSIVE
+			armor_penetration = ARMOR_PEN_MASSIVE
 			slowdown = 0.10
 			slowdown_hold = 0.10
 		if(100)
 			armor_list = list(melee = 10, bullet = 10, energy = 10, bomb = 0, bio = 0, rad = 0)
 			force = WEAPON_FORCE_LETHAL + 5
-			armor_divisor = ARMOR_PEN_MASSIVE + 5
+			armor_penetration = ARMOR_PEN_MASSIVE + 5
 			slowdown = 0.05
 			slowdown_hold = 0.05
 
@@ -950,7 +950,7 @@
 		//Endless Growth
 		name = "mass grave marker shield"
 		force += 1
-		armor_divisor += 1
+		armor_penetration += 1
 		post_moder_game_balance *= 1.1 //150 x 1.1 = 165 -> 165 x 1.1 = 181.5(182) ect ect
 		post_moder_game_balance = round(post_moder_game_balance)
 

--- a/code/modules/projectiles/guns/projectile/revolver/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/revolver.dm
@@ -19,7 +19,7 @@
 	price_tag = 650
 	fire_delay = 3 //all revolvers can fire faster, but have huge recoil
 	damage_multiplier = 1.2
-	armor_divisor = -0.35 // Insanely powerful handcannon, but worthless against heavy armor
+	armor_penetration = -4 // Insanely powerful handcannon, but worthless against heavy armor
 	init_recoil = HANDGUN_RECOIL(1.3)
 	gun_tags = list(GUN_PROJECTILE, GUN_INTERNAL_MAG, GUN_REVOLVER)
 	var/drawChargeMeter = TRUE

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -129,6 +129,8 @@
 
 	var/ignition_source = TRUE //Used for deciding if a projectile should blow up a benzin.
 
+	var/armor_maximum = -3 //The value is intentionally negative. This is essentially "3" armor during the armor calculation proc.
+
 /obj/item/projectile/New()
 
 	penetration_holder = new /datum/penetration_holder

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -176,7 +176,7 @@
 		damage_types[HALLOSS] *= newmult
 
 /obj/item/projectile/add_projectile_penetration(newmult)
-	armor_divisor = initial(armor_divisor) + newmult
+	armor_penetration = initial(armor_penetration) + newmult
 
 /obj/item/projectile/multiply_pierce_penetration(newmult)
 	penetrating = initial(penetrating) + newmult
@@ -285,11 +285,11 @@
 			for (var/entry in livingfirer.projectile_damage_increment)
 				damage_types[entry] += livingfirer.projectile_damage_increment[entry]
 
-		if (livingfirer.projectile_armor_divisor_mult != 1)
-			add_projectile_penetration(livingfirer.projectile_armor_divisor_mult)
+		if (livingfirer.projectile_armor_penetration_mult != 1)
+			add_projectile_penetration(livingfirer.projectile_armor_penetration_mult)
 
-		if (livingfirer.projectile_armor_divisor_adjustment)
-			armor_divisor *= livingfirer.projectile_armor_divisor_adjustment
+		if (livingfirer.projectile_armor_penetration_adjustment)
+			armor_penetration *= livingfirer.projectile_armor_penetration_adjustment
 
 		if (livingfirer.projectile_speed_mult != 1)
 			multiply_projectile_step_delay(livingfirer.projectile_speed_mult)
@@ -898,7 +898,7 @@
 				damage_drop_off = max(1, range_shot - affective_damage_range) / 100 //How far we were shot - are affective range. This one is for damage drop off
 				ap_drop_off = max(1, range_shot - affective_ap_range) //How far we were shot - are affective range. This one is for AP drop off
 
-				armor_divisor = max(0, armor_divisor - ap_drop_off)
+				armor_penetration = max(0, armor_penetration - ap_drop_off)
 
 				agony = max(0, agony - range_shot) //every step we lose one agony, this stops sniping with rubbers.
 				//log_and_message_admins("LOG 2| range shot [range_shot] | drop ap [ap_drop_off] | drop damg | [damage_drop_off] | penetrating [penetrating].")
@@ -967,7 +967,7 @@
 				damage_drop_off = max(1, range_shot - affective_damage_range) / 100 //How far we were shot - are affective range. This one is for damage drop off
 				ap_drop_off = max(1, range_shot - affective_ap_range) //How far we were shot - are affective range. This one is for AP drop off
 
-				armor_divisor = max(0, armor_divisor - ap_drop_off)
+				armor_penetration = max(0, armor_penetration - ap_drop_off)
 
 				agony = max(0, agony - range_shot) //every step we lose one agony, this stops sniping with rubbers.
 				//log_and_message_admins("LOG 2| range shot [range_shot] | drop ap [ap_drop_off] | drop damg | [damage_drop_off] | penetrating [penetrating].")
@@ -1112,7 +1112,7 @@
 			P.activate(P.lifetime)
 
 /obj/item/projectile/proc/block_damage(var/amount, atom/A)
-	amount /= armor_divisor
+	amount /= armor_penetration
 	var/dmg_total = 0
 	var/dmg_remaining = 0
 	for(var/dmg_type in damage_types)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -129,7 +129,7 @@
 
 	var/ignition_source = TRUE //Used for deciding if a projectile should blow up a benzin.
 
-	var/armor_maximum = -3 //The value is intentionally negative. This is essentially "3" armor during the armor calculation proc.
+	var/armor_maximum = 3 //This is a sort of 'one shot protection' against armor, allowing armor to still retain up to 3 points of their armor if it's overpenned.
 
 /obj/item/projectile/New()
 

--- a/code/modules/projectiles/projectile/ameridian.dm
+++ b/code/modules/projectiles/projectile/ameridian.dm
@@ -5,7 +5,7 @@
 	hitsound_wall = 'sound/weapons/guns/misc/laser_searwall.ogg'
 	damage_types = list(BURN  = 40) // 20 more damage than the Cog
 	irradiate = 15
-	armor_divisor = 1.15 //less AP than the Cog
+	armor_penetration = 2 //less AP than the Cog
 	check_armour = ARMOR_ENERGY
 	hitscan = TRUE
 	invisibility = 101	//beam projectiles are invisible as they are rendered by the effect engine
@@ -20,7 +20,7 @@
 	name = "ameridian shard"
 	damage_types = list(BRUTE = 30) //Were a bit better then 10mm to stay competitive
 	irradiate = 10
-	armor_divisor = 1.15
+	armor_penetration = 2
 	check_armour = ARMOR_BULLET
 	embed = TRUE
 	shrapnel_type = /obj/item/material/shard/ameridian

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -11,7 +11,7 @@ In pvp they also have more lasting damages, such as infections, pain form burns,
 	hitsound_wall = 'sound/weapons/guns/misc/laser_searwall.ogg'
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
 	damage_types = list(BURN = 20)
-	armor_divisor = 1.2 //Some AP
+	armor_penetration = 3 //Some AP
 	wounding_mult = 1.2 //and some wounding mult
 	check_armour = ARMOR_ENERGY
 	var/frequency = 1
@@ -29,7 +29,7 @@ In pvp they also have more lasting damages, such as infections, pain form burns,
 /obj/item/projectile/beam/check_penetrate(var/atom/A) // For shields to actually block projectiles
 	if(istype(A, /obj/item/shield))
 		var/obj/item/shield/S = A
-		var/loss = round(S.durability / armor_divisor * 8)
+		var/loss = round(S.durability / armor_penetration * 8)
 		block_damage(loss, A)
 		A.visible_message(SPAN_WARNING("\The [src] is weakened by the \the [A]!"))
 		playsound(A.loc, 'sound/weapons/shield/shielddissipate.ogg', 50, 1)
@@ -38,22 +38,22 @@ In pvp they also have more lasting damages, such as infections, pain form burns,
 
 /obj/item/projectile/beam/musket
 	name = "Musket laser"
-	armor_divisor = 2.5 //Good AP, its for slow firing weapon
+	armor_penetration = 4 //Good AP, its for slow firing weapon
 	eyeblur = 1
 	damage_types = list(BURN = 25) //According to Rain Chule recommendation
 
 /obj/item/projectile/beam/drone
 	damage_types = list(BURN = 15)
-	armor_divisor = 1.1 //Some AP
+	armor_penetration = 2 //Some AP
 	recoil = 2
 
 /obj/item/projectile/beam/pulse/drone
 	damage_types = list(BURN = 10)
-	armor_divisor = 1 //No AP we deal 30 damage in 3 shots
+	armor_penetration = 0 //No AP we deal 30 damage in 3 shots
 
 /obj/item/projectile/beam/weak
 	damage_types = list(BURN = 16)
-	armor_divisor = 1.15 //Some AP
+	armor_penetration = 1 //Some AP
 	recoil = 2
 
 // Laser bullets are your premium and expensive upgrade to your traditional bullets.
@@ -64,52 +64,52 @@ In pvp they also have more lasting damages, such as infections, pain form burns,
 // 223 is a middle ground between 408 and 75. Damage of 408, AP of 75
 /obj/item/projectile/beam/laser_223
 	damage_types = list(BURN = 20)
-	armor_divisor = 2
+	armor_penetration = 3
 	recoil = 5
 	wounding_mult = WOUNDING_SERIOUS
 /*
 /obj/item/projectile/beam/laser_223/ap
 	damage_types = list(BURN = 16)
-	armor_divisor = 3
+	armor_penetration = 3
 	recoil = 7
 	wounding_mult = WOUNDING_NORMAL
 	penetrating = 1
 
 /obj/item/projectile/beam/laser_223/lethal
 	damage_types = list(BURN = 27)
-	armor_divisor = 1
+	armor_penetration = 1
 	recoil = 5
 	wounding_mult = WOUNDING_WIDE
 */
 
 /obj/item/projectile/beam/weak/pistol_35
 	damage_types = list(BURN = 15)
-	armor_divisor = 2
+	armor_penetration = 2
 	recoil = 2.5
 
 /obj/item/projectile/beam/weak/light_rifle_257
 	damage_types = list(BURN = 14)
-	armor_divisor = 3
+	armor_penetration = 4
 	recoil = 3.5
 
 /obj/item/projectile/beam/weak/rifle_75
 	damage_types = list(BURN = 15.5)
-	armor_divisor = 3
+	armor_penetration = 6
 	recoil = 5
 
 /obj/item/projectile/beam/weak/heavy_rifle_408
 	damage_types = list(BURN = 20)
-	armor_divisor = 4
+	armor_penetration = 6
 	recoil = 10
 
 /obj/item/projectile/beam/weak/magnum_40
 	damage_types = list(BURN = 19)
-	armor_divisor = 3
+	armor_penetration = 6
 	recoil = 4.5
 
 /obj/item/projectile/beam/weak/kurtz_50
 	damage_types = list(BURN = 23.5)
-	armor_divisor = 3
+	armor_penetration = 8
 	recoil = 8
 
 /obj/item/projectile/beam/weak/smg
@@ -121,23 +121,23 @@ In pvp they also have more lasting damages, such as infections, pain form burns,
 
 /obj/item/projectile/beam/weak/lethal
 	damage_types = list(BURN = 20)
-	armor_divisor = 1 //cant have negitive armor sadly
+	armor_penetration = -1 //cant have negitive armor sadly   :) Well, now you can!
 
 /obj/item/projectile/beam/weak/ap
 	damage_types = list(BURN = 15)
-	armor_divisor = 1.25
+	armor_penetration = 1
 
 /obj/item/projectile/beam/weak/ap/reaver
 	damage_types = list(BURN = 16.5)
 
 /obj/item/projectile/beam/shotgun
 	damage_types = list(BURN = 35) //Normal slugs deal 45
-	armor_divisor = 1.1
+	armor_penetration = 1
 	recoil = 2
 
 /obj/item/projectile/beam/shotgun/strong
 	damage_types = list(BURN = 54) // Default slug (/obj/item/projectile/bullet/shotgun) deal 54 damage
-	armor_divisor = 1.1
+	armor_penetration = 2
 	eyeblur = 4
 	recoil = 4
 
@@ -151,13 +151,13 @@ In pvp they also have more lasting damages, such as infections, pain form burns,
 
 /obj/item/projectile/beam/midlaser // Middle ground between better than stock but worse than heavy.
 	damage_types = list(BURN = 25)
-	armor_divisor = 1.25
+	armor_penetration = 2
 
 /obj/item/projectile/beam/heavylaser
 	name = "heavy laser"
 	icon_state = "heavylaser"
 	damage_types = list(BURN = 35)
-	armor_divisor = 1.5
+	armor_penetration = 3
 	wounding_mult = 1.3
 	eyeblur = 4
 	muzzle_type = /obj/effect/projectile/laser_heavy/muzzle
@@ -169,7 +169,7 @@ In pvp they also have more lasting damages, such as infections, pain form burns,
 	name = "x-ray beam"
 	icon_state = "xray"
 	damage_types = list(BURN = 25)
-	armor_divisor = 2.25
+	armor_penetration = 8
 	wounding_mult = 1
 	eyeblur = 4
 	recoil = 1
@@ -182,7 +182,7 @@ In pvp they also have more lasting damages, such as infections, pain form burns,
 	name = "pulse"
 	icon_state = "u_laser"
 	damage_types = list(BURN = 40)
-	armor_divisor = 2 //it's a pulse blast.
+	armor_penetration = 4 //it's a pulse blast.
 	wounding_mult = 1.5
 	eyeblur = 4
 	recoil = 3
@@ -198,7 +198,7 @@ In pvp they also have more lasting damages, such as infections, pain form burns,
 /obj/item/projectile/beam/pulse/heavy
 	name = "heavy pulse"
 	damage_types = list(BURN = 50)
-	armor_divisor = 2.25
+	armor_penetration = 3
 	recoil = 5
 
 /obj/item/projectile/beam/emitter
@@ -214,7 +214,7 @@ In pvp they also have more lasting damages, such as infections, pain form burns,
 	name = "nuclear beam"
 	icon_state = "emitter"
 	damage_types = list(BURN = 40)
-	armor_divisor = 1.75 //Experimental and extremely rare but also self recharging so take it as you will
+	armor_penetration = 2 //Experimental and extremely rare but also self recharging so take it as you will
 	recoil = 7
 
 	muzzle_type = /obj/effect/projectile/emitter/muzzle
@@ -234,7 +234,7 @@ In pvp they also have more lasting damages, such as infections, pain form burns,
 	name = "dissolver ray"
 	icon_state = "emitter"
 	damage_types = list(BURN = 30) //Less burn but also less recoil
-	armor_divisor = 4 //Experimental and extremely rare but also self recharging so take it as you will
+	armor_penetration = 6 //Experimental and extremely rare but also self recharging so take it as you will
 	recoil = 5 //Less recoil but also less burn
 
 	muzzle_type = /obj/effect/projectile/emitter/muzzle
@@ -254,7 +254,7 @@ In pvp they also have more lasting damages, such as infections, pain form burns,
 	name = "desolator ray"
 	icon_state = "xray"
 	damage_types = list(BURN = 20) //Worse Xray
-	armor_divisor = 2
+	armor_penetration = 4
 	eyeblur = 4
 	recoil = 6
 	penetrating = 1
@@ -276,7 +276,7 @@ In pvp they also have more lasting damages, such as infections, pain form burns,
 	name = "sniper beam"
 	icon_state = "xray"
 	damage_types = list(BURN = 50)
-	armor_divisor = 2
+	armor_penetration = 4
 	//stun = 3
 	//weaken = 3
 	//stutter = 3
@@ -289,7 +289,7 @@ In pvp they also have more lasting damages, such as infections, pain form burns,
 /obj/item/projectile/beam/stun
 	name = "stun beam"
 	icon_state = "stun"
-	armor_divisor = 1
+	armor_penetration = 0
 	nodamage = 1
 	taser_effect = 1
 	damage_types = list(BURN = 1, HALLOSS = 30)
@@ -316,7 +316,7 @@ In pvp they also have more lasting damages, such as infections, pain form burns,
 	name = "lighting"
 	icon_state = "stun"
 	damage_types = list(BURN = 10, HALLOSS = 5)
-	armor_divisor = 1
+	armor_penetration = 2
 	eyeblur = 0
 
 	muzzle_type = /obj/effect/projectile/stun/muzzle
@@ -328,7 +328,7 @@ In pvp they also have more lasting damages, such as infections, pain form burns,
 	name = "sin"
 	icon_state = "xray"
 	damage_types = list(TOX = 10)
-	armor_divisor = 1
+	armor_penetration = 2
 	eyeblur = 0
 	muzzle_type = /obj/effect/projectile/xray/muzzle
 	tracer_type = /obj/effect/projectile/xray/tracer
@@ -339,7 +339,7 @@ In pvp they also have more lasting damages, such as infections, pain form burns,
 	name = "grace"
 	icon_state = "xray"
 	damage_types = list(TOX = 0)//Shouldnt do anything but just in case its toxin
-	armor_divisor = 1
+	armor_penetration = 0
 	stun = 0
 	weaken = 0
 	eyeblur = 0
@@ -372,7 +372,7 @@ In pvp they also have more lasting damages, such as infections, pain form burns,
 /obj/item/projectile/beam/tesla
 	name = "lightning"
 	damage_types = list(BURN = 30)
-	armor_divisor = 1.1
+	armor_penetration = 1
 	hitscan = TRUE
 
 	muzzle_type = /obj/effect/projectile/tesla/muzzle
@@ -391,7 +391,7 @@ In pvp they also have more lasting damages, such as infections, pain form burns,
 	name = "infrared radiation"
 	icon_state = "invisible"
 	damage_types = list(BURN = 15)
-	armor_divisor = 1.25 //less ap
+	armor_penetration = 2 //less ap
 	eyeblur = 0
 	muzzle_type = null
 	tracer_type = null

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -70,26 +70,26 @@ Bullet also tend to have more armor against them do to this and can be douged un
 	var/chance = 0
 	if(istype(A, /turf/simulated/wall)) // TODO: refactor this from functional into OOP
 		var/turf/simulated/wall/W = A
-		chance = round(penetrating/2 * armor_divisor * 2 / W.material.integrity * 180)
+		chance = round(penetrating/2 * armor_penetration * 2 / W.material.integrity * 180)
 	else if(istype(A, /obj/item/shield))
 		var/obj/item/shield/S = A
-		chance = round(armor_divisor * 2 / S.durability * 180)
+		chance = round(armor_penetration * 2 / S.durability * 180)
 	else if(istype(A, /obj/machinery/door))
 		var/obj/machinery/door/D = A
-		chance = round(penetrating/2 * armor_divisor * 2 / D.maxHealth * 180)
+		chance = round(penetrating/2 * armor_penetration * 2 / D.maxHealth * 180)
 		if(D.glass) chance *= 2
 	else if(istype(A, /obj/structure/girder))
 		chance = 100
 	else if(istype(A, /obj/structure/low_wall))
-		chance = round(penetrating/2 * armor_divisor * 2 / 150 * 180) // hardcoded, value is same as steel wall, will have to be changed once low walls have integrity
+		chance = round(penetrating/2 * armor_penetration * 2 / 150 * 180) // hardcoded, value is same as steel wall, will have to be changed once low walls have integrity
 	else if(istype(A, /obj/structure/table))
 		var/obj/structure/table/T = A
-		chance = round(penetrating/2 * armor_divisor * 2 / T.maxHealth * 180)
+		chance = round(penetrating/2 * armor_penetration * 2 / T.maxHealth * 180)
 	else if(istype(A, /obj/structure/barricade))
 		var/obj/structure/barricade/B = A
-		chance = round(penetrating/2 * armor_divisor * 2 / B.material.integrity * 180)
+		chance = round(penetrating/2 * armor_penetration * 2 / B.material.integrity * 180)
 	else if(istype(A, /obj/machinery) || istype(A, /obj/structure))
-		chance = armor_divisor * penetrating/2
+		chance = armor_penetration * penetrating/2
 
 	if(prob(chance) || (A in holder.force_penetration_on))
 		if(A.opacity || istype(A, /obj/item/shield))

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -12,7 +12,7 @@
 ///9mm///
 /obj/item/projectile/bullet/pistol_35
 	damage_types = list(BRUTE = 24)
-	armor_divisor = 0.4
+	armor_penetration = 1
 	step_delay = 0.65
 	can_ricochet = TRUE
 	wounding_mult = WOUNDING_SMALL
@@ -22,7 +22,7 @@
 
 /obj/item/projectile/bullet/pistol_35/hv
 	damage_types = list(BRUTE = 18)
-	armor_divisor = 1.2
+	armor_penetration = 2
 	step_delay = 0.5
 	affective_damage_range = 5
 	affective_ap_range = 5
@@ -42,7 +42,7 @@
 /obj/item/projectile/bullet/pistol_35/lethal
 	name = "hollow-point bullet"
 	damage_types = list(BRUTE = 18)
-	armor_divisor = 0.2
+	armor_penetration = 0
 	wounding_mult = WOUNDING_NORMAL
 	penetrating = 0
 	can_ricochet = FALSE
@@ -55,7 +55,7 @@
 	name = "rubber bullet"
 	icon_state = "rubber"
 	damage_types = list(BRUTE = 12, HALLOSS = 22)
-	armor_divisor = 0.4
+	armor_penetration = 1
 	wounding_mult = WOUNDING_SMALL
 	embed = FALSE	//Prob should have a chance to embed, but makes close to no sense to do this for 9mm at least.
 	sharp = FALSE
@@ -116,7 +116,7 @@
 
 /obj/item/projectile/bullet/pistol_35/scrap
 	damage_types = list(BRUTE = 14)
-	armor_divisor = 0.25
+	armor_penetration = 0
 	affective_damage_range = 1
 	affective_ap_range = 1
 	recoil = 3
@@ -139,7 +139,7 @@
 /obj/item/projectile/bullet/magnum_40
 	icon_state = "bullet_magnum"
 	damage_types = list(BRUTE = 28)
-	armor_divisor = 0.5
+	armor_penetration = 1
 	wounding_mult = WOUNDING_NORMAL
 	can_ricochet = TRUE
 	step_delay = 0.4
@@ -159,7 +159,7 @@
 
 /obj/item/projectile/bullet/magnum_40/hv
 	damage_types = list(BRUTE = 22)
-	armor_divisor = 1.3
+	armor_penetration = 3
 	penetrating = 1
 	step_delay = 0.25
 	nocap_structures = TRUE //Door breaching
@@ -171,7 +171,7 @@
 /obj/item/projectile/bullet/magnum_40/lethal
 	name = "hollow-point bullet"
 	damage_types = list(BRUTE = 22)
-	armor_divisor = 0.25
+	armor_penetration = 0
 	wounding_mult = WOUNDING_SERIOUS
 	penetrating = 0
 	can_ricochet = FALSE
@@ -184,7 +184,7 @@
 	name = "rubber bullet"
 	icon_state = "rubber"
 	damage_types = list(BRUTE = 15, HALLOSS = 30)	//Basically a lower-damage HP but with more agony damage to it. Technically LTL - but not really ideal for it. Crowd-suppression.
-	armor_divisor = 0.5
+	armor_penetration = 1
 	wounding_mult = WOUNDING_SMALL
 	embed = TRUE	//If you shoot someone with a rubber, it will take out an eye - or require surgery if it's high-velocity. Anything over 9mm should, realistically, fuck you up.
 	sharp = FALSE
@@ -235,7 +235,7 @@
 
 /obj/item/projectile/bullet/magnum_40/scrap
 	damage_types = list(BRUTE = 15)
-	armor_divisor = 0.5
+	armor_penetration = 1
 	affective_damage_range = 3
 	affective_ap_range = 3
 	recoil = 6
@@ -243,7 +243,7 @@
 /obj/item/projectile/bullet/magnum_40/biomatter
 	name = "biomatter bullet"
 	damage_types = list(BURN = 20, HALLOSS = 32)
-	armor_divisor = 0.7
+	armor_penetration = 1
 	penetrating = 0
 	can_ricochet = FALSE
 	embed = FALSE
@@ -256,7 +256,7 @@
 /obj/item/projectile/bullet/kurtz_50
 	icon_state = "bullet_krutz"
 	damage_types = list(BRUTE = 36)
-	armor_divisor = 0.6
+	armor_penetration = 3
 	wounding_mult = WOUNDING_WIDE
 	can_ricochet = TRUE
 	embed = TRUE
@@ -271,7 +271,7 @@
 	damage_types = list(BRUTE = 20, HALLOSS = 35)
 	wounding_mult = WOUNDING_SERIOUS
 	check_armour = ARMOR_MELEE
-	armor_divisor = 0.5
+	armor_penetration = 2
 	can_ricochet = TRUE
 	//ricochet_mod = 2 //including our AP mallus for bounce we are baseline about 1.9x as likely to bounce.
 	step_delay = 0.7
@@ -310,7 +310,7 @@
 /obj/item/projectile/bullet/kurtz_50/lethal
 	name = "hollow-point bullet"
 	damage_types = list(BRUTE = 27)
-	armor_divisor = 0.3
+	armor_penetration = 1
 	wounding_mult = WOUNDING_EXTREME
 	penetrating = 0
 	can_ricochet = FALSE
@@ -320,7 +320,7 @@
 /obj/item/projectile/bullet/kurtz_50/hv
 	name = "AV bullet"
 	damage_types = list(BRUTE = 27)
-	armor_divisor = 1.4
+	armor_penetration = 6
 	penetrating = 2
 	can_ricochet = FALSE
 	step_delay = 0.45
@@ -339,7 +339,7 @@
 /obj/item/projectile/bullet/light_rifle_257
 	icon_state = "bullet_carbine"
 	damage_types = list(BRUTE = 21)
-	armor_divisor = 1
+	armor_penetration = 0
 	wounding_mult = WOUNDING_SMALL
 	penetrating = 1
 	can_ricochet = TRUE
@@ -359,7 +359,7 @@
 
 /obj/item/projectile/bullet/light_rifle_257/hv
 	damage_types = list(BRUTE = 17)
-	armor_divisor = 2.5
+	armor_penetration = 3
 	penetrating = 2
 	hitscan = TRUE
 	affective_damage_range = 8 //Can snipe
@@ -373,7 +373,7 @@
 	icon_state = "rubber"
 	damage_types = list(BRUTE = 10, HALLOSS = 20)
 	check_armour = ARMOR_MELEE
-	armor_divisor = 0.8
+	armor_penetration = 1
 	wounding_mult = WOUNDING_TINY
 	embed = TRUE	//Imagine being shot with a high velocity .223/5.56 rubber bullet - that shit could easily kill you - or at least would act like a normal bullet.
 	sharp = FALSE
@@ -405,7 +405,7 @@
 /obj/item/projectile/bullet/light_rifle_257/lethal
 	name = "hollow-point bullet"
 	damage_types = list(BRUTE = 17)
-	armor_divisor = 0.5
+	armor_penetration = 0
 	wounding_mult = WOUNDING_SERIOUS
 	penetrating = 0
 	can_ricochet = FALSE
@@ -418,7 +418,7 @@
 	name = "incendiary bullet"
 	damage_types = list(BURN = 10) //We deal most of are damage with fire stacks
 	fire_stacks = 1
-	armor_divisor = 0.5
+	armor_penetration = 0
 	penetrating = 0
 	can_ricochet = FALSE
 	embed = FALSE
@@ -429,7 +429,7 @@
 
 /obj/item/projectile/bullet/light_rifle_257/scrap
 	damage_types = list(BRUTE = 14)
-	armor_divisor = 0.5
+	armor_penetration = 1
 	affective_damage_range = 4
 	affective_ap_range = 4
 	recoil = 6
@@ -441,7 +441,7 @@
 
 /obj/item/projectile/bullet/rifle_75
 	damage_types = list(BRUTE = 25)
-	armor_divisor = 1.25
+	armor_penetration = 2
 	wounding_mult = WOUNDING_SERIOUS
 	penetrating = 1
 	can_ricochet = TRUE
@@ -452,7 +452,7 @@
 
 /obj/item/projectile/bullet/rifle_75/hv
 	damage_types = list(BRUTE = 19)
-	armor_divisor = 3
+	armor_penetration = 6
 	penetrating = 2
 	hitscan = TRUE
 	affective_damage_range = 8
@@ -464,7 +464,7 @@
 /obj/item/projectile/bullet/rifle_75/practice
 	name = "practice bullet"
 	damage_types = list(BRUTE = 2, HALLOSS = 2)
-	armor_divisor = 1
+	armor_penetration = 0
 	embed = FALSE
 	sharp = FALSE
 	can_ricochet = FALSE
@@ -475,7 +475,7 @@
 	icon_state = "rubber"
 	damage_types = list(BRUTE = 14, HALLOSS = 26)
 	check_armour = ARMOR_MELEE
-	armor_divisor = 1
+	armor_penetration = 1
 	wounding_mult = WOUNDING_NORMAL
 	embed = TRUE	//literally imagine a 7.62 rubber bullet hitting you - holy shit.
 	sharp = FALSE
@@ -505,7 +505,7 @@
 /obj/item/projectile/bullet/rifle_75/lethal
 	name = "hollow-point bullet"
 	damage_types = list(BRUTE = 19)
-	armor_divisor = 0.65
+	armor_penetration = 0
 	wounding_mult = WOUNDING_WIDE
 	penetrating = 0
 	can_ricochet = FALSE
@@ -527,7 +527,7 @@
 
 /obj/item/projectile/bullet/rifle_75/scrap
 	damage_types = list(BRUTE = 14)
-	armor_divisor = 0.5
+	armor_penetration = 1
 	affective_damage_range = 3
 	affective_ap_range = 3
 	recoil = 5
@@ -537,7 +537,7 @@
 /obj/item/projectile/bullet/heavy_rifle_408
 	icon_state = "bullet_heavy"
 	damage_types = list(BRUTE = 28)
-	armor_divisor = 1.4
+	armor_penetration = 0
 	wounding_mult = WOUNDING_SERIOUS
 	penetrating = 2
 	can_ricochet = TRUE
@@ -550,7 +550,7 @@
 	name = "rubber bullet"
 	icon_state = "rubber"
 	damage_types = list(BRUTE = 17, HALLOSS = 32)
-	armor_divisor = 1.3
+	armor_penetration = 1
 	check_armour = ARMOR_MELEE
 	embed = TRUE	//imagine an effectively smaller .50 Cal marksman round hitting you. holy shit.
 	sharp = FALSE
@@ -563,7 +563,7 @@
 /obj/item/projectile/bullet/heavy_rifle_408/practice
 	name = "practice bullet"
 	damage_types = list(BRUTE = 6)
-	armor_divisor = 1
+	armor_penetration = 1
 	embed = FALSE
 	sharp = FALSE
 	wounding_mult = WOUNDING_NORMAL
@@ -574,7 +574,7 @@
 /obj/item/projectile/bullet/heavy_rifle_408/hv
 	name = "sabot penetrator"
 	damage_types = list(BRUTE = 20)
-	armor_divisor = 3.5
+	armor_penetration = 12
 	penetrating = 3
 	hitscan = TRUE
 	affective_damage_range = 9 //Sniping cal
@@ -586,7 +586,7 @@
 /obj/item/projectile/bullet/heavy_rifle_408/lethal
 	name = "hollow-point bullet"
 	damage_types = list(BRUTE = 20)
-	armor_divisor = 0.7
+	armor_penetration = 1
 	wounding_mult = WOUNDING_WIDE
 	penetrating = 0
 	can_ricochet = FALSE
@@ -599,7 +599,7 @@
 	name = "incendiary bullet"
 	damage_types = list(BURN = 15) //We deal most of are damage with fire stacks
 	fire_stacks = 3
-	armor_divisor = 1
+	armor_penetration = 1
 	penetrating = 0
 	can_ricochet = FALSE
 	embed = FALSE
@@ -609,7 +609,7 @@
 
 /obj/item/projectile/bullet/heavy_rifle_408/scrap
 	damage_types = list(BRUTE = 15)
-	armor_divisor = 0.75
+	armor_penetration = 1
 	affective_damage_range = 4
 	affective_ap_range = 4
 	recoil = 12
@@ -618,7 +618,7 @@
 
 /obj/item/projectile/bullet/c10x24
 	damage_types = list(BRUTE = 20)
-	armor_divisor = 2
+	armor_penetration = 2
 	wounding_mult = WOUNDING_SMALL
 	penetrating = 2
 	can_ricochet = TRUE
@@ -630,7 +630,7 @@
 
 /obj/item/projectile/bullet/auto_460
 	damage_types = list(BRUTE = 30)
-	armor_divisor = 1.25
+	armor_penetration = 2
 	penetrating = 2
 	can_ricochet = TRUE
 	step_delay = 0.3
@@ -640,7 +640,7 @@
 
 /obj/item/projectile/bullet/auto_460/scrap
 	damage_types = list(BRUTE = 17.5)
-	armor_divisor = 1.15
+	armor_penetration = 1
 	penetrating = 1
 	can_ricochet = TRUE
 	step_delay = 0.3
@@ -651,7 +651,7 @@
 //// 14.5×114mm Anti-Materiel Rifle Rounds ////
 /obj/item/projectile/bullet/antim
 	damage_types = list(BRUTE = 60)
-	armor_divisor = 10
+	armor_penetration = 16
 	wounding_mult = WOUNDING_WIDE
 	nocap_structures = TRUE
 	//stun = 5
@@ -665,7 +665,7 @@
 /obj/item/projectile/bullet/antim/lethal
 	damage_types = list(BRUTE = 45, HALLOSS = 100)
 	embed = TRUE
-	armor_divisor = 4
+	armor_penetration = 8
 	wounding_mult = WOUNDING_EXTREME
 	penetrating = 2
 	affective_damage_range = 9
@@ -677,7 +677,7 @@
 	damage_types = list(BURN = 45)
 	embed = FALSE
 	fire_stacks = 5	//BURN, BABY! BUUURN!!
-	armor_divisor = 4
+	armor_penetration = 4
 	penetrating = 2
 	affective_damage_range = 10
 	affective_ap_range = 10
@@ -686,14 +686,14 @@
 
 /obj/item/projectile/bullet/antim/scrap
 	damage_types = list(BRUTE = 40)
-	armor_divisor = 4
+	armor_penetration = 4
 	affective_damage_range = 8
 	affective_ap_range = 8
 	recoil = 30
 
 /obj/item/projectile/bullet/antim/ion
 	damage_types = list(BRUTE = 25)
-	armor_divisor = 4
+	armor_penetration = 4
 	recoil = 15
 
 /obj/item/projectile/bullet/antim/ion/on_impact(atom/target, blocked = FALSE)
@@ -705,7 +705,7 @@
 /obj/item/projectile/bullet/ball
 	nocap_structures = TRUE
 	damage_types = list(BRUTE = 40, HALLOSS = 60) //Grab me musket as the founding fathers intended
-	armor_divisor = 4 //no longer a little jank, much like other older rifles it falters in terms of AP while still having enough to really smash through armor.
+	armor_penetration = 4 //no longer a little jank, much like other older rifles it falters in terms of AP while still having enough to really smash through armor.
 	supereffective_mult = 6 //we do 40 damage base, up to 240 with supereffective - plus AP bonus, plus agony bonus, about the same 350~ as before
 	supereffective_types = list(/mob/living/carbon/human = FALSE, /mob/living = TRUE) //We are great at fighting living things(other than people, for balance reasons) but not so much robots.
 	wounding_mult = WOUNDING_EXTREME
@@ -721,7 +721,7 @@
 	name = "coilgun round"
 	icon_state = null
 	damage_types = list(BRUTE = 26)
-	armor_divisor = 2
+	armor_penetration = 4
 	wounding_mult = WOUNDING_SERIOUS
 	penetrating = 1
 
@@ -736,7 +736,7 @@
 	name = "flak shrapnel"
 	icon_state = "l_birdshot-4"
 	damage_types = list(BRUTE = 14)
-	armor_divisor = 1.5
+	armor_penetration = 4
 	wounding_mult = WOUNDING_NORMAL
 	penetrating = 0
 
@@ -766,7 +766,7 @@
 	icon_state = "bullet_heavy"
 	damage_types = list(BRUTE = 21)
 	wounding_mult = WOUNDING_SERIOUS
-	armor_divisor = 1.25 //To keep it somewhat fair towards the handhelds considering it has higher ammo capacity
+	armor_penetration = 2 //To keep it somewhat fair towards the handhelds considering it has higher ammo capacity
 	penetrating = 1
 
 	can_ricochet = TRUE
@@ -779,7 +779,7 @@
 	name = "gigantic round"
 	icon_state = "slug"
 	damage_types = list(BRUTE = 56)
-	armor_divisor = 4 //Tally ho
+	armor_penetration = 6 //Tally ho
 	wounding_mult = WOUNDING_EXTREME
 	penetrating = 3 //tank sized round
 
@@ -793,7 +793,7 @@
 	name = "humongous round"
 	icon_state = "bullet_kurtz"
 	damage_types = list(BRUTE = 26)
-	armor_divisor = 3 //This fires 2 in a row so keep that in mind
+	armor_penetration = 4 //This fires 2 in a row so keep that in mind
 	wounding_mult = WOUNDING_SERIOUS
 	penetrating = 3 //tank sized round
 
@@ -810,7 +810,7 @@
 	name = "slug"
 	icon_state = "slug"
 	damage_types = list(BRUTE = 35)
-	armor_divisor = 3
+	armor_penetration = 2
 	wounding_mult = WOUNDING_SERIOUS
 	knockback = 0 //Bug doups hits
 	step_delay = 0.9
@@ -823,7 +823,7 @@
 	name = "ceramic slug"
 	icon_state = "slug"
 	damage_types = list(BRUTE = 30)
-	armor_divisor = 1.2
+	armor_penetration = 1
 	knockback = 1 //KER-BLAM!!!!
 	affective_damage_range = 4
 	affective_ap_range = 4
@@ -834,7 +834,7 @@
 	icon_state = "rubber"
 	damage_types = list(BRUTE = 20, HALLOSS = 60)
 	wounding_mult = WOUNDING_NORMAL
-	armor_divisor = 1.5
+	armor_penetration = 0
 	embed = FALSE
 	sharp = FALSE
 	step_delay = 1.65
@@ -847,7 +847,7 @@
 	name = "pepperball slug"
 	damage_types = list(BRUTE = 6, HALLOSS = 50)	//Pepperballs disipate upon impact. They'll sting like shit, but won't do much in a low-velocity round.
 	step_delay = 2 //Slower than a beanbag due to it being STRONG as fuck.
-	armor_divisor = 0.8
+	armor_penetration = 0
 	var/spray = "condensedcapsaicin"
 	embed = FALSE
 	can_ricochet = FALSE	//breaks upon impact; impossible.
@@ -867,7 +867,7 @@
 /obj/item/projectile/bullet/shotgun/beanbag/soporific
 	name = "soporific coated beanbag"
 	damage_types = list(BRUTE = 10, HALLOSS = 65) // They still hurt!
-	armor_divisor = 0.8
+	armor_penetration = 0
 	var/spray = "stoxin"
 
 /obj/item/projectile/bullet/shotgun/beanbag/soporific/New()
@@ -886,7 +886,7 @@
 /obj/item/projectile/bullet/shotgun/practice
 	name = "practice slug"
 	damage_types = list(BRUTE = 4, HALLOSS = 5)
-	armor_divisor = 0.5
+	armor_penetration = 0
 	embed = FALSE
 	affective_damage_range = 1
 	affective_ap_range = 1
@@ -895,27 +895,27 @@
 /obj/item/projectile/bullet/shotgun/incendiary
 	//This is the best ammo for pvp in a shotgun, beating the stunshell with its pain and cooks anyone in any armor!
 	damage_types = list(BURN = 22.5) //We deal most of are damage with fire stacks
-	armor_divisor = 0.5
+	armor_penetration = 0
 	fire_stacks = 4 //40 pain a fire proc through ALL armor!
 	recoil = 40
 
 /obj/item/projectile/bullet/shotgun/scrap
 	damage_types = list(BRUTE = 27)
-	armor_divisor = 1.2
+	armor_penetration = 0
 	affective_damage_range = 3
 	affective_ap_range = 4
 	recoil = 10
 
 /obj/item/projectile/bullet/shotgun/beanbag/scrap
 	damage_types = list(BRUTE = 13, HALLOSS  = 55)
-	armor_divisor = 1.25
+	armor_penetration = 0
 	affective_damage_range = 1
 	affective_ap_range = 1
 	recoil = 8
 
 /obj/item/projectile/bullet/pellet/shotgun/scrap
 	damage_types = list(BRUTE = 8)
-	armor_divisor = 0.9
+	armor_penetration = 0
 	affective_damage_range = 4
 	affective_ap_range = 4
 	recoil = 6
@@ -923,7 +923,7 @@
 /obj/item/projectile/bullet/shotgun/biomatter //Unique niche round. High AP, Low damage, high agony. Good for mob crunching, or AP LTL uses
 	name = "biomatter slug"
 	damage_types = list(BURN = 10, HALLOSS = 40) // Thin little piece of biomass designed to defeat armor but not really large enough to cause super serious injuries.
-	armor_divisor = 4 //high velocity
+	armor_penetration = 3 //high velocity
 	wounding_mult = WOUNDING_SMALL //tiny slug.
 	penetrating = 0
 	can_ricochet = FALSE
@@ -1006,7 +1006,7 @@
 	mob_hit_sound = list('sound/effects/gore/sear.ogg')
 	hitsound_wall = 'sound/weapons/guns/misc/ric4.ogg'
 	damage_types = list(BRUTE = 40)
-	armor_divisor = 4
+	armor_penetration = 12
 	check_armour = ARMOR_BULLET
 	embed = FALSE
 	can_ricochet = FALSE
@@ -1022,7 +1022,7 @@
 	name = "shrapnel"
 	icon_state = "birdshot-1"
 	damage_types = list(BRUTE = 16)
-	armor_divisor = 0.6
+	armor_penetration = 0
 	wounding_mult = WOUNDING_SMALL //lotta relatively smaller pellets.
 	pellets = 4
 	range_step = 1
@@ -1051,7 +1051,7 @@
 	name = "Unstable energy bolt"
 	icon_state = "l_birdshot-1"
 	damage_types = list(BURN = 11.5) //slightly less than buck, but FAR more painful
-	armor_divisor = 2 //heated shot melt armor.
+	armor_penetration = 4 //heated shot melt armor.
 	embed = FALSE
 	can_ricochet = FALSE
 	sharp = FALSE
@@ -1067,7 +1067,7 @@
 	wounding_mult = WOUNDING_EXTREME //Shredding
 	knockback = 1
 	fire_stacks = 1
-	armor_divisor = 10
+	armor_penetration = 10
 	nocap_structures = TRUE
 	check_armour = ARMOR_BOMB
 	sharp = TRUE
@@ -1102,7 +1102,7 @@
 	icon_state = "bolt"
 	damage_types = list(BRUTE = 25)
 	wounding_mult = WOUNDING_SERIOUS //decent but won't like armor
-	armor_divisor = 1.3
+	armor_penetration = 3
 	knockback = 0 //Bug doups hits
 	supereffective_types = list(/mob/living/carbon/human = FALSE, /mob/living = TRUE)
 	supereffective_mult = 1.5
@@ -1116,7 +1116,7 @@
 	icon_state = "bolt"
 	damage_types = list(BRUTE = 30)
 	wounding_mult = WOUNDING_WIDE //slightly bigger
-	armor_divisor = 0.5
+	armor_penetration = 0
 	supereffective_types = list(/mob/living/carbon/human = FALSE, /mob/living = TRUE)
 	supereffective_mult = 1.5
 	step_delay = 0.9
@@ -1126,7 +1126,7 @@
 	name = "bolt"
 	icon_state = "bolt"
 	damage_types = list(BRUTE = 20)
-	armor_divisor = 3
+	armor_penetration = 8
 	penetrating = 3
 	hitscan = TRUE
 	sharp = TRUE
@@ -1151,7 +1151,7 @@
 	name = "metal rod"
 	icon_state = "bolt"
 	damage_types = list(BRUTE = 5) //This is multiplied by tension when fired, so it's actually 25 damage.
-	armor_divisor = 1.25
+	armor_penetration = 2
 	wounding_mult = WOUNDING_NORMAL //it's a whole ass rod.
 	step_delay = 0.9
 	embed = FALSE
@@ -1163,7 +1163,7 @@
 /obj/item/projectile/bullet/reusable/rod_bolt/superheated
 	name = "superheated metal rod"
 	damage_types = list(BRUTE = 5, BURN = 2.5) //This is multiplied by tension when fired, so it's actually 37.5 damage.
-	armor_divisor = 1.5
+	armor_penetration = 4
 	wounding_mult = WOUNDING_SERIOUS //it's a SUPER HOT whole ass bolt.
 	step_delay = 0.6
 	embed = TRUE
@@ -1178,7 +1178,7 @@
 	name = "flashforged rod"
 	icon_state = "bolt"
 	damage_types = list(BRUTE = 5) //This is multiplied by tension when fired, so it's actually 25 damage. Slightly worse, but it's faster and has higher AP.
-	armor_divisor = 2
+	armor_penetration = 6
 	step_delay = 0.6
 	embed = FALSE
 	penetrating = 1
@@ -1191,7 +1191,7 @@
 	name = "flashforged superheated rod"
 	icon_state = "bolt"
 	damage_types = list(BRUTE = 5, BURN = 2.5) //This is multiplied by tension when fired, so it's actually 57.5 damage. Slightly worse, but it's faster and has higher AP.
-	armor_divisor = 20
+	armor_penetration = 100
 	step_delay = 0.2
 	embed = TRUE
 	penetrating = 2
@@ -1204,7 +1204,7 @@
 	name = "arrow"
 	icon_state = "arrow"
 	damage_types = list(BRUTE = 2) //Multiplied by 10 when fired.
-	armor_divisor = 0.3
+	armor_penetration = 1
 	effective_faction = list("wurm", "roach", "spider", "vox_tribe", "russian", "tengo") //good against common colony mobs
 	damage_mult = 2 // Turns out arrows always sucked
 	embed = FALSE //don't want to embed and drop an arrow, that would be weird
@@ -1223,7 +1223,7 @@
 	damage_types = list(BRUTE = 1.5) // 15 damage at max pull
 	damage_mult = 1.5 // Less bonus damage against effective faction
 	embed_mult = 3 //we are going to try really hard to embed
-	armor_divisor = 0.75 // Crossbow bolts are better, however this should not penetrate armor the same as a bullet (if not MORE).
+	armor_penetration = 2 // Crossbow bolts are better, however this should not penetrate armor the same as a bullet (if not MORE).
 	hitscan = TRUE // As every HV ammo
 	affective_damage_range = 8
 	affective_ap_range = 8
@@ -1236,7 +1236,7 @@
 	icon_state = "arrow-broad"
 	damage_types = list(BRUTE = 4.5) //Very good base damage, negligible (5) AP, but no embedding. Think of it as arrow-hollowpoints.
 	embed = FALSE
-	armor_divisor = 0.2
+	armor_penetration = 0
 	create_type = /obj/item/ammo_casing/arrow/broadhead
 
 /obj/item/projectile/bullet/reusable/arrow/hunting
@@ -1245,7 +1245,7 @@
 	damage_types = list(BRUTE = 1) //Multiplied by 10 when fired.
 	supereffective_types = list(/mob/living/carbon/human = FALSE, /mob/living = TRUE)
 	supereffective_mult = 5 //we do 10 damage base, up to 50 against SE mobs, then with 50 AP on should do ~100. Slow to fire, unwieldly, slow projectiles (but reusable), so I'll say this is fair?
-	armor_divisor = 1 //high ap to take advantage of overpen on mobs
+	armor_penetration = 4 //high ap to take advantage of overpen on mobs
 	step_delay = 0.7 // 20% faster than normal arrows
 	affective_damage_range = 8 //worse than the baroque, but better than regular arrows
 	affective_ap_range = 8
@@ -1255,7 +1255,7 @@
 	name = "fragmenting hunting arrow"
 	icon_state = "arrow-bone"
 	damage_types = list(BRUTE = 2) //Multiplied by 10 when fired.
-	armor_divisor = 0.75
+	armor_penetration = 1
 	embed = TRUE
 	hitscan = TRUE // Sniping round, fast
 	supereffective_mult = 18 //we do 20 damage base, up to 360 against SE mobs, then with 55 (+5 hunting bow) AP on should do ~410. Baroque is around ~430 vs mobs, so roughly baroque-tier vs mobs, with the same wieldliness and different ammo costs (bone/leather/metal/plastic vs metal/cardboard).

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -16,16 +16,16 @@
 	step_delay = 0.65
 	can_ricochet = TRUE
 	wounding_mult = WOUNDING_SMALL
-	affective_damage_range = 4
-	affective_ap_range = 4
+	affective_damage_range = 3
+	affective_ap_range = 3
 	recoil = 5
 
 /obj/item/projectile/bullet/pistol_35/hv
-	damage_types = list(BRUTE = 18)
+	damage_types = list(BRUTE = 22)
 	armor_penetration = 2
 	step_delay = 0.5
-	affective_damage_range = 5
-	affective_ap_range = 5
+	affective_damage_range = 6
+	affective_ap_range = 6
 	can_ricochet = TRUE
 	sharp = TRUE
 	recoil = 6
@@ -41,7 +41,7 @@
 
 /obj/item/projectile/bullet/pistol_35/lethal
 	name = "hollow-point bullet"
-	damage_types = list(BRUTE = 18)
+	damage_types = list(BRUTE = 22)
 	armor_penetration = 0
 	wounding_mult = WOUNDING_NORMAL
 	penetrating = 0
@@ -54,7 +54,7 @@
 /obj/item/projectile/bullet/pistol_35/rubber
 	name = "rubber bullet"
 	icon_state = "rubber"
-	damage_types = list(BRUTE = 12, HALLOSS = 22)
+	damage_types = list(BRUTE = 2, HALLOSS = 15)
 	armor_penetration = 1
 	wounding_mult = WOUNDING_SMALL
 	embed = FALSE	//Prob should have a chance to embed, but makes close to no sense to do this for 9mm at least.
@@ -95,7 +95,7 @@
 
 /obj/item/projectile/bullet/pistol_35/rubber/pepperball
 	name = "pepperball"
-	damage_types = list(BRUTE = 2, HALLOSS = 22)	//Pepperballs disipate upon impact. They'll sting like shit, but won't do much in a low-velocity round.
+	damage_types = list(BRUTE = 2, HALLOSS = 10)	//Pepperballs disipate upon impact. They'll sting like shit, but won't do much in a low-velocity round.
 	step_delay = 0.6 //a little slower than rubber rounds - these are just pepperspray balls
 	var/spray = "condensedcapsaicin"
 	embed = FALSE
@@ -115,15 +115,15 @@
 			reagents.trans_to_mob(L, 3, CHEM_TOUCH, copy = FALSE)
 
 /obj/item/projectile/bullet/pistol_35/scrap
-	damage_types = list(BRUTE = 14)
+	damage_types = list(BRUTE = 12)
 	armor_penetration = 0
-	affective_damage_range = 1
-	affective_ap_range = 1
+	affective_damage_range = 2
+	affective_ap_range = 2
 	recoil = 3
 
 /obj/item/projectile/bullet/pistol_35/biomatter
 	name = "biomatter bullet"
-	damage_types = list(BURN = 15, HALLOSS = 20)
+	damage_types = list(BURN = 15, HALLOSS = 10)
 	penetrating = 0
 	can_ricochet = FALSE
 	embed = FALSE
@@ -138,8 +138,8 @@
 
 /obj/item/projectile/bullet/magnum_40
 	icon_state = "bullet_magnum"
-	damage_types = list(BRUTE = 28)
-	armor_penetration = 1
+	damage_types = list(BRUTE = 26)
+	armor_penetration = 2
 	wounding_mult = WOUNDING_NORMAL
 	can_ricochet = TRUE
 	step_delay = 0.4
@@ -158,8 +158,8 @@
 	recoil = 4
 
 /obj/item/projectile/bullet/magnum_40/hv
-	damage_types = list(BRUTE = 22)
-	armor_penetration = 3
+	damage_types = list(BRUTE = 24)
+	armor_penetration = 6
 	penetrating = 1
 	step_delay = 0.25
 	nocap_structures = TRUE //Door breaching
@@ -170,7 +170,7 @@
 
 /obj/item/projectile/bullet/magnum_40/lethal
 	name = "hollow-point bullet"
-	damage_types = list(BRUTE = 22)
+	damage_types = list(BRUTE = 24)
 	armor_penetration = 0
 	wounding_mult = WOUNDING_SERIOUS
 	penetrating = 0
@@ -183,8 +183,8 @@
 /obj/item/projectile/bullet/magnum_40/rubber
 	name = "rubber bullet"
 	icon_state = "rubber"
-	damage_types = list(BRUTE = 15, HALLOSS = 30)	//Basically a lower-damage HP but with more agony damage to it. Technically LTL - but not really ideal for it. Crowd-suppression.
-	armor_penetration = 1
+	damage_types = list(BRUTE = 5, HALLOSS = 25)	//Basically a lower-damage HP but with more agony damage to it. Technically LTL - but not really ideal for it. Crowd-suppression.
+	armor_penetration = 0
 	wounding_mult = WOUNDING_SMALL
 	embed = TRUE	//If you shoot someone with a rubber, it will take out an eye - or require surgery if it's high-velocity. Anything over 9mm should, realistically, fuck you up.
 	sharp = FALSE
@@ -196,7 +196,7 @@
 
 /obj/item/projectile/bullet/magnum_40/rubber/pepperball
 	name = "pepperball"
-	damage_types = list(BRUTE = 4, HALLOSS = 30)	//Pepperballs disipate upon impact. They'll sting like shit, but won't do much in a low-velocity round.
+	damage_types = list(BRUTE = 5, HALLOSS = 15)	//Pepperballs disipate upon impact. They'll sting like shit, but won't do much in a low-velocity round.
 	step_delay = 0.6 //a little slower than rubber rounds - these are just pepperspray balls
 	var/spray = "condensedcapsaicin"
 	embed = FALSE
@@ -234,7 +234,7 @@
 			reagents.trans_to_mob(L, 3, CHEM_TOUCH, copy = FALSE)
 
 /obj/item/projectile/bullet/magnum_40/scrap
-	damage_types = list(BRUTE = 15)
+	damage_types = list(BRUTE = 18)
 	armor_penetration = 1
 	affective_damage_range = 3
 	affective_ap_range = 3
@@ -242,7 +242,7 @@
 
 /obj/item/projectile/bullet/magnum_40/biomatter
 	name = "biomatter bullet"
-	damage_types = list(BURN = 20, HALLOSS = 32)
+	damage_types = list(BURN = 20, HALLOSS = 25)
 	armor_penetration = 1
 	penetrating = 0
 	can_ricochet = FALSE
@@ -256,19 +256,19 @@
 /obj/item/projectile/bullet/kurtz_50
 	icon_state = "bullet_krutz"
 	damage_types = list(BRUTE = 36)
-	armor_penetration = 3
+	armor_penetration = 4
 	wounding_mult = WOUNDING_WIDE
 	can_ricochet = TRUE
 	embed = TRUE
 	step_delay = 0.65
-	affective_damage_range = 5
-	affective_ap_range = 5
+	affective_damage_range = 6  // Essentially a pocket sniper!
+	affective_ap_range = 6
 	recoil = 14
 
 /obj/item/projectile/bullet/kurtz_50/rubber
 	name = "rubber bullet"
 	icon_state = "rubber"
-	damage_types = list(BRUTE = 20, HALLOSS = 35)
+	damage_types = list(BRUTE = 10, HALLOSS = 40)  // These would hurt. A LOT.
 	wounding_mult = WOUNDING_SERIOUS
 	check_armour = ARMOR_MELEE
 	armor_penetration = 2
@@ -280,7 +280,7 @@
 
 /obj/item/projectile/bullet/kurtz_50/rubber/pepperball
 	name = "pepperball"
-	damage_types = list(BRUTE = 6, HALLOSS = 35)	//Pepperballs disipate upon impact. They'll sting like shit, but won't do much in a low-velocity round.
+	damage_types = list(BRUTE = 10, HALLOSS = 25)	//Pepperballs disipate upon impact. They'll sting like shit, but won't do much in a low-velocity round.
 	step_delay = 0.75 //a little slower than rubber rounds - these are just pepperspray balls
 	var/spray = "condensedcapsaicin"
 	embed = FALSE
@@ -302,6 +302,7 @@
 /obj/item/projectile/bullet/kurtz_50/practice
 	name = "practice bullet"
 	damage_types = list(BRUTE = 5)
+	armor_penetration = 0
 	embed = FALSE
 	can_ricochet = FALSE
 	step_delay = 0.75
@@ -309,8 +310,8 @@
 
 /obj/item/projectile/bullet/kurtz_50/lethal
 	name = "hollow-point bullet"
-	damage_types = list(BRUTE = 27)
-	armor_penetration = 1
+	damage_types = list(BRUTE = 30)
+	armor_penetration = 0
 	wounding_mult = WOUNDING_EXTREME
 	penetrating = 0
 	can_ricochet = FALSE
@@ -319,13 +320,13 @@
 
 /obj/item/projectile/bullet/kurtz_50/hv
 	name = "AV bullet"
-	damage_types = list(BRUTE = 27)
-	armor_penetration = 6
+	damage_types = list(BRUTE = 32)
+	armor_penetration = 8
 	penetrating = 2
 	can_ricochet = FALSE
 	step_delay = 0.45
-	affective_damage_range = 6
-	affective_ap_range = 6
+	affective_damage_range = 8
+	affective_ap_range = 8
 	nocap_structures = TRUE //We can breach doors rather well
 	sharp = TRUE
 	recoil = 16
@@ -338,19 +339,19 @@
 
 /obj/item/projectile/bullet/light_rifle_257
 	icon_state = "bullet_carbine"
-	damage_types = list(BRUTE = 21)
+	damage_types = list(BRUTE = 19)
 	armor_penetration = 0
 	wounding_mult = WOUNDING_SMALL
 	penetrating = 1
 	can_ricochet = TRUE
 	step_delay = 0.3
-	affective_damage_range = 7
-	affective_ap_range = 7
+	affective_damage_range = 6
+	affective_ap_range = 6
 	recoil = 5
 
 /obj/item/projectile/bullet/light_rifle_257/practice
 	name = "practice bullet"
-	damage_types = list(BRUTE = 4)
+	damage_types = list(BRUTE = 2)
 	embed = FALSE
 	sharp = FALSE
 	can_ricochet = FALSE
@@ -359,7 +360,7 @@
 
 /obj/item/projectile/bullet/light_rifle_257/hv
 	damage_types = list(BRUTE = 17)
-	armor_penetration = 3
+	armor_penetration = 4
 	penetrating = 2
 	hitscan = TRUE
 	affective_damage_range = 8 //Can snipe
@@ -371,7 +372,7 @@
 /obj/item/projectile/bullet/light_rifle_257/rubber
 	name = "rubber bullet"
 	icon_state = "rubber"
-	damage_types = list(BRUTE = 10, HALLOSS = 20)
+	damage_types = list(BRUTE = 5, HALLOSS = 15)
 	check_armour = ARMOR_MELEE
 	armor_penetration = 1
 	wounding_mult = WOUNDING_TINY
@@ -384,7 +385,7 @@
 
 /obj/item/projectile/bullet/light_rifle_257/rubber/pepperball
 	name = "pepperball"
-	damage_types = list(BRUTE = 4, HALLOSS = 20)	//Pepperballs disipate upon impact. They'll sting like shit, but won't do much in a low-velocity round.
+	damage_types = list(BRUTE = 5, HALLOSS = 10)	//Pepperballs disipate upon impact. They'll sting like shit, but won't do much in a low-velocity round.
 	step_delay = 1.0 //a little slower than rubber rounds - these are just pepperspray balls
 	var/spray = "condensedcapsaicin"
 	embed = FALSE
@@ -404,7 +405,7 @@
 
 /obj/item/projectile/bullet/light_rifle_257/lethal
 	name = "hollow-point bullet"
-	damage_types = list(BRUTE = 17)
+	damage_types = list(BRUTE = 18)
 	armor_penetration = 0
 	wounding_mult = WOUNDING_SERIOUS
 	penetrating = 0
@@ -416,20 +417,20 @@
 
 /obj/item/projectile/bullet/light_rifle_257/incend
 	name = "incendiary bullet"
-	damage_types = list(BURN = 10) //We deal most of are damage with fire stacks
+	damage_types = list(BURN = 8) //We deal most of are damage with fire stacks
 	fire_stacks = 1
-	armor_penetration = 0
-	penetrating = 0
+	armor_penetration = -1
+	penetrating = 2 // Burn, baby, burn!!! Essentially make any carbine turn into a mini flamethrower.
 	can_ricochet = FALSE
 	embed = FALSE
 	sharp = FALSE
-	wounding_mult = WOUNDING_NORMAL
+	wounding_mult = WOUNDING_SMALL
 	step_delay = 0.7
 	recoil = 7
 
 /obj/item/projectile/bullet/light_rifle_257/scrap
-	damage_types = list(BRUTE = 14)
-	armor_penetration = 1
+	damage_types = list(BRUTE = 15)
+	armor_penetration = 0
 	affective_damage_range = 4
 	affective_ap_range = 4
 	recoil = 6
@@ -440,9 +441,9 @@
 /// 7.62x39mm Rifle ///
 
 /obj/item/projectile/bullet/rifle_75
-	damage_types = list(BRUTE = 25)
-	armor_penetration = 2
-	wounding_mult = WOUNDING_SERIOUS
+	damage_types = list(BRUTE = 24)
+	armor_penetration = 3
+	wounding_mult = WOUNDING_NORMAL
 	penetrating = 1
 	can_ricochet = TRUE
 	step_delay = 0.3
@@ -451,8 +452,8 @@
 	recoil = 10
 
 /obj/item/projectile/bullet/rifle_75/hv
-	damage_types = list(BRUTE = 19)
-	armor_penetration = 6
+	damage_types = list(BRUTE = 20)
+	armor_penetration = 8
 	penetrating = 2
 	hitscan = TRUE
 	affective_damage_range = 8
@@ -463,7 +464,7 @@
 
 /obj/item/projectile/bullet/rifle_75/practice
 	name = "practice bullet"
-	damage_types = list(BRUTE = 2, HALLOSS = 2)
+	damage_types = list(BRUTE = 2, HALLOSS = 4)
 	armor_penetration = 0
 	embed = FALSE
 	sharp = FALSE
@@ -473,9 +474,9 @@
 /obj/item/projectile/bullet/rifle_75/rubber
 	name = "rubber bullet"
 	icon_state = "rubber"
-	damage_types = list(BRUTE = 14, HALLOSS = 26)
+	damage_types = list(BRUTE = 10, HALLOSS = 20)
 	check_armour = ARMOR_MELEE
-	armor_penetration = 1
+	armor_penetration = 0
 	wounding_mult = WOUNDING_NORMAL
 	embed = TRUE	//literally imagine a 7.62 rubber bullet hitting you - holy shit.
 	sharp = FALSE
@@ -504,7 +505,7 @@
 
 /obj/item/projectile/bullet/rifle_75/lethal
 	name = "hollow-point bullet"
-	damage_types = list(BRUTE = 19)
+	damage_types = list(BRUTE = 20)
 	armor_penetration = 0
 	wounding_mult = WOUNDING_WIDE
 	penetrating = 0
@@ -516,9 +517,8 @@
 
 /obj/item/projectile/bullet/rifle_75/incend
 	name = "incendiary bullet"
-	damage_types = list(BURN = 12) //We deal most of are damage with fire stacks
+	damage_types = list(BURN = 10) //We deal most of are damage with fire stacks
 	fire_stacks = 2
-	penetrating = 0
 	can_ricochet = FALSE
 	embed = FALSE
 	sharp = FALSE
@@ -526,7 +526,7 @@
 	recoil = 9
 
 /obj/item/projectile/bullet/rifle_75/scrap
-	damage_types = list(BRUTE = 14)
+	damage_types = list(BRUTE = 16)
 	armor_penetration = 1
 	affective_damage_range = 3
 	affective_ap_range = 3
@@ -536,27 +536,27 @@
 
 /obj/item/projectile/bullet/heavy_rifle_408
 	icon_state = "bullet_heavy"
-	damage_types = list(BRUTE = 28)
-	armor_penetration = 0
+	damage_types = list(BRUTE = 30)
+	armor_penetration = 2
 	wounding_mult = WOUNDING_SERIOUS
-	penetrating = 2
+	penetrating = 1
 	can_ricochet = TRUE
-	step_delay = 0.3
-	affective_damage_range = 8
-	affective_ap_range = 8
+	step_delay = 0.2
+	affective_damage_range = 9
+	affective_ap_range = 9
 	recoil = 16
 
 /obj/item/projectile/bullet/heavy_rifle_408/rubber
 	name = "rubber bullet"
 	icon_state = "rubber"
-	damage_types = list(BRUTE = 17, HALLOSS = 32)
-	armor_penetration = 1
+	damage_types = list(BRUTE = 10, HALLOSS = 25)
+	armor_penetration = 0
 	check_armour = ARMOR_MELEE
 	embed = TRUE	//imagine an effectively smaller .50 Cal marksman round hitting you. holy shit.
 	sharp = FALSE
 	can_ricochet = TRUE
 	//ricochet_mod = 1.35 //after AP penalty to ricochet is factored in we have more like 15% more chance to ricochet.
-	step_delay = 0.9
+	step_delay = 0.8
 	recoil = 14
 	ignition_source = FALSE
 
@@ -573,7 +573,7 @@
 
 /obj/item/projectile/bullet/heavy_rifle_408/hv
 	name = "sabot penetrator"
-	damage_types = list(BRUTE = 20)
+	damage_types = list(BRUTE = 28)
 	armor_penetration = 12
 	penetrating = 3
 	hitscan = TRUE
@@ -585,9 +585,9 @@
 
 /obj/item/projectile/bullet/heavy_rifle_408/lethal
 	name = "hollow-point bullet"
-	damage_types = list(BRUTE = 20)
-	armor_penetration = 1
-	wounding_mult = WOUNDING_WIDE
+	damage_types = list(BRUTE = 26)
+	armor_penetration = 0
+	wounding_mult = WOUNDING_EXTREME
 	penetrating = 0
 	can_ricochet = FALSE
 	embed = TRUE
@@ -597,10 +597,10 @@
 
 /obj/item/projectile/bullet/heavy_rifle_408/incend
 	name = "incendiary bullet"
-	damage_types = list(BURN = 15) //We deal most of are damage with fire stacks
+	damage_types = list(BURN = 16) //We deal most of are damage with fire stacks
 	fire_stacks = 3
-	armor_penetration = 1
-	penetrating = 0
+	armor_penetration = 2
+	penetrating = 1   //BUUURRRN! HAHHAHA!
 	can_ricochet = FALSE
 	embed = FALSE
 	sharp = FALSE
@@ -608,10 +608,11 @@
 	recoil = 15
 
 /obj/item/projectile/bullet/heavy_rifle_408/scrap
-	damage_types = list(BRUTE = 15)
-	armor_penetration = 1
-	affective_damage_range = 4
-	affective_ap_range = 4
+	damage_types = list(BRUTE = 18)
+	armor_penetration = 2
+	affective_damage_range = 6
+	affective_ap_range = 6
+	step_delay = 0.6
 	recoil = 12
 
 ///Snowflake  ///
@@ -639,7 +640,7 @@
 	recoil = 14
 
 /obj/item/projectile/bullet/auto_460/scrap
-	damage_types = list(BRUTE = 17.5)
+	damage_types = list(BRUTE = 18)
 	armor_penetration = 1
 	penetrating = 1
 	can_ricochet = TRUE
@@ -663,13 +664,13 @@
 	recoil = 40
 
 /obj/item/projectile/bullet/antim/lethal
-	damage_types = list(BRUTE = 45, HALLOSS = 100)
+	damage_types = list(BRUTE = 55, HALLOSS = 40) // Im shocked this had 100 HALLOSS previously.
 	embed = TRUE
-	armor_penetration = 8
+	armor_penetration = 6
 	wounding_mult = WOUNDING_EXTREME
-	penetrating = 2
-	affective_damage_range = 9
-	affective_ap_range = 9
+	penetrating = 1
+	affective_damage_range = 8
+	affective_ap_range = 8
 	penetrating = -5
 	recoil = 20
 
@@ -704,9 +705,9 @@
 //smoothbore rifles
 /obj/item/projectile/bullet/ball
 	nocap_structures = TRUE
-	damage_types = list(BRUTE = 40, HALLOSS = 60) //Grab me musket as the founding fathers intended
+	damage_types = list(BRUTE = 40, HALLOSS = 30) //Grab me musket as the founding fathers intended
 	armor_penetration = 4 //no longer a little jank, much like other older rifles it falters in terms of AP while still having enough to really smash through armor.
-	supereffective_mult = 6 //we do 40 damage base, up to 240 with supereffective - plus AP bonus, plus agony bonus, about the same 350~ as before
+	supereffective_mult = 6
 	supereffective_types = list(/mob/living/carbon/human = FALSE, /mob/living = TRUE) //We are great at fighting living things(other than people, for balance reasons) but not so much robots.
 	wounding_mult = WOUNDING_EXTREME
 	penetrating = 2
@@ -809,43 +810,43 @@
 /obj/item/projectile/bullet/shotgun
 	name = "slug"
 	icon_state = "slug"
-	damage_types = list(BRUTE = 35)
-	armor_penetration = 2
+	damage_types = list(BRUTE = 36)
+	armor_penetration = 4
 	wounding_mult = WOUNDING_SERIOUS
 	knockback = 0 //Bug doups hits
 	step_delay = 0.9
 	//Slugs are meant for long range shooting
-	affective_damage_range = 7
-	affective_ap_range = 7
+	affective_damage_range = 6
+	affective_ap_range = 6
 	recoil = 18
 
 /obj/item/projectile/bullet/shotgun/ceramic
 	name = "ceramic slug"
 	icon_state = "slug"
-	damage_types = list(BRUTE = 30)
-	armor_penetration = 1
+	damage_types = list(BRUTE = 33)
+	armor_penetration = 2
 	knockback = 1 //KER-BLAM!!!!
-	affective_damage_range = 4
-	affective_ap_range = 4
+	affective_damage_range = 2
+	affective_ap_range = 2
 	recoil = 22
 
 /obj/item/projectile/bullet/shotgun/beanbag
 	name = "beanbag"
 	icon_state = "rubber"
-	damage_types = list(BRUTE = 20, HALLOSS = 60)
+	damage_types = list(BRUTE = 10, HALLOSS = 45)
 	wounding_mult = WOUNDING_NORMAL
 	armor_penetration = 0
 	embed = FALSE
 	sharp = FALSE
 	step_delay = 1.65
-	affective_damage_range = 5
-	affective_ap_range = 2
+	affective_damage_range = 6
+	affective_ap_range = 5
 	recoil = 10
 	ignition_source = FALSE
 
 /obj/item/projectile/bullet/shotgun/beanbag/pepperball
 	name = "pepperball slug"
-	damage_types = list(BRUTE = 6, HALLOSS = 50)	//Pepperballs disipate upon impact. They'll sting like shit, but won't do much in a low-velocity round.
+	damage_types = list(BRUTE = 2, HALLOSS = 60)	//Pepperballs disipate upon impact. They'll sting like shit, but won't do much in a low-velocity round.
 	step_delay = 2 //Slower than a beanbag due to it being STRONG as fuck.
 	armor_penetration = 0
 	var/spray = "condensedcapsaicin"
@@ -866,7 +867,7 @@
 
 /obj/item/projectile/bullet/shotgun/beanbag/soporific
 	name = "soporific coated beanbag"
-	damage_types = list(BRUTE = 10, HALLOSS = 65) // They still hurt!
+	damage_types = list(BRUTE = 2, HALLOSS = 70) // They still hurt!
 	armor_penetration = 0
 	var/spray = "stoxin"
 
@@ -894,20 +895,20 @@
 
 /obj/item/projectile/bullet/shotgun/incendiary
 	//This is the best ammo for pvp in a shotgun, beating the stunshell with its pain and cooks anyone in any armor!
-	damage_types = list(BURN = 22.5) //We deal most of are damage with fire stacks
+	damage_types = list(BURN = 24) //We deal most of are damage with fire stacks
 	armor_penetration = 0
 	fire_stacks = 4 //40 pain a fire proc through ALL armor!
 	recoil = 40
 
 /obj/item/projectile/bullet/shotgun/scrap
-	damage_types = list(BRUTE = 27)
+	damage_types = list(BRUTE = 24)
 	armor_penetration = 0
 	affective_damage_range = 3
 	affective_ap_range = 4
 	recoil = 10
 
 /obj/item/projectile/bullet/shotgun/beanbag/scrap
-	damage_types = list(BRUTE = 13, HALLOSS  = 55)
+	damage_types = list(BRUTE = 20, HALLOSS  = 30) // Pretty much a lug of junk shot out of a barrel wrapped in cotton. Might kill before less than lethaling.
 	armor_penetration = 0
 	affective_damage_range = 1
 	affective_ap_range = 1
@@ -922,14 +923,14 @@
 
 /obj/item/projectile/bullet/shotgun/biomatter //Unique niche round. High AP, Low damage, high agony. Good for mob crunching, or AP LTL uses
 	name = "biomatter slug"
-	damage_types = list(BURN = 10, HALLOSS = 40) // Thin little piece of biomass designed to defeat armor but not really large enough to cause super serious injuries.
-	armor_penetration = 3 //high velocity
+	damage_types = list(BURN = 5, HALLOSS = 35) // Thin little piece of biomass designed to defeat armor but not really large enough to cause super serious injuries.
+	armor_penetration = 8 //high velocity
 	wounding_mult = WOUNDING_SMALL //tiny slug.
-	penetrating = 0
+	penetrating = 1
 	can_ricochet = FALSE
 	embed = FALSE
 	sharp = FALSE
-	step_delay = 0.95 //slightly slower than a slug
+	step_delay = 0.7
 	check_armour = ARMOR_BIO //duh.
 	recoil = 8//much less damage than slug, much less recoil.
 
@@ -1021,7 +1022,7 @@
 /obj/item/projectile/bullet/pellet/shotgun
 	name = "shrapnel"
 	icon_state = "birdshot-1"
-	damage_types = list(BRUTE = 16)
+	damage_types = list(BRUTE = 12, HALLOSS = 8) // Lots of tiny pellets. A good chunk just bounces off armor!
 	armor_penetration = 0
 	wounding_mult = WOUNDING_SMALL //lotta relatively smaller pellets.
 	pellets = 4
@@ -1035,7 +1036,7 @@
 
 /obj/item/projectile/bullet/pellet/shotgun/Initialize()
 	. = ..()
-	icon_state = "birdshot-[rand(1,4)]"
+	icon_state = "birdshot-[rand(1,6)]" // It's BIRDSHOT! Let it FEEL like birdshot!
 
 /obj/item/projectile/bullet/pellet/shotgun/scattershot //VERY dangerous, the weapon has a low refire rate for a reason. DO NOT use this for non exo weapons without tweaking.
 	name = "heavy shrapnel"
@@ -1050,7 +1051,7 @@
 /obj/item/projectile/bullet/pellet/shotgun/energy
 	name = "Unstable energy bolt"
 	icon_state = "l_birdshot-1"
-	damage_types = list(BURN = 11.5) //slightly less than buck, but FAR more painful
+	damage_types = list(BURN = 10, HALLOSS = 4) //slightly less than buck, but FAR more painful
 	armor_penetration = 4 //heated shot melt armor.
 	embed = FALSE
 	can_ricochet = FALSE
@@ -1100,7 +1101,7 @@
 /obj/item/projectile/bullet/crossbow_bolt
 	name = "bolt"
 	icon_state = "bolt"
-	damage_types = list(BRUTE = 25)
+	damage_types = list(BRUTE = 26)
 	wounding_mult = WOUNDING_SERIOUS //decent but won't like armor
 	armor_penetration = 3
 	knockback = 0 //Bug doups hits
@@ -1125,7 +1126,7 @@
 /obj/item/projectile/bullet/crossbow_bolt/hv
 	name = "bolt"
 	icon_state = "bolt"
-	damage_types = list(BRUTE = 20)
+	damage_types = list(BRUTE = 24)
 	armor_penetration = 8
 	penetrating = 3
 	hitscan = TRUE
@@ -1323,10 +1324,10 @@
 	effective_faction = null
 	damage_types = list(HALLOSS = 1)
 	embed = FALSE //impact fuze
-	step_delay = 1.1 //slower
+	step_delay = 1.2 //slower
 	affective_damage_range = 6
 	affective_ap_range = 6
-	kill_count = 7 //heavy arrow, worse aerodynamics
+	kill_count = 8 //heavy arrow, worse aerodynamics
 	create_type = null
 	ignition_source = TRUE
 

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -49,7 +49,7 @@
 	name = "electrode"
 	icon_state = "spark"
 	mob_hit_sound = list('sound/weapons/tase.ogg')
-	armor_divisor= 1.2
+	armor_penetration= 1
 	nodamage = 1
 	taser_effect = 1
 	damage_types = list(HALLOSS = 40)

--- a/code/modules/projectiles/projectile/hydrogen.dm
+++ b/code/modules/projectiles/projectile/hydrogen.dm
@@ -4,7 +4,7 @@
 	mob_hit_sound = list('sound/effects/gore/sear.ogg')
 	hitsound_wall = 'sound/weapons/guns/misc/laser_searwall.ogg'
 	damage_types = list(BURN = 70)
-	armor_divisor = 2.25
+	armor_penetration = 3
 	check_armour = ARMOR_ENERGY
 	muzzle_type = /obj/effect/projectile/plasma/muzzle
 	impact_type = /obj/effect/projectile/plasma/impact
@@ -38,15 +38,15 @@
 // Overcharged Shots
 /obj/item/projectile/hydrogen/max
 	damage_types = list(BURN = 90)
-	armor_divisor = 2.75
+	armor_penetration = 4
 	recoil = 40
 
 /obj/item/projectile/hydrogen/pistol/max
 	damage_types = list(BURN = 80)
-	armor_divisor = 2.5
+	armor_penetration = 3
 	recoil = 20
 
 /obj/item/projectile/hydrogen/cannon/max
 	damage_types = list(BURN = 100)
-	armor_divisor = 3
+	armor_penetration = 6
 	recoil = 60

--- a/code/modules/projectiles/projectile/plasma.dm
+++ b/code/modules/projectiles/projectile/plasma.dm
@@ -4,7 +4,7 @@
 	mob_hit_sound = list('sound/effects/gore/sear.ogg')
 	hitsound_wall = 'sound/weapons/guns/misc/laser_searwall.ogg'
 	damage_types = list(BURN = 28)
-	armor_divisor = 1.1
+	armor_penetration = 1
 	check_armour = ARMOR_ENERGY
 	fire_stacks = 1 //Blasma
 
@@ -24,7 +24,7 @@
 /obj/item/projectile/plasma/light
 	name = "light plasma bolt"
 	damage_types = list(BURN = 33)
-	armor_divisor = 0.65
+	armor_penetration = 1
 	recoil = 7
 
 /obj/item/projectile/plasma/heavy
@@ -36,7 +36,7 @@
 	fire_stacks = 1
 
 	damage_types = list(BURN = 30)
-	armor_divisor = 2.3
+	armor_penetration = 3
 
 /obj/item/projectile/plasma/heavy/shell
 	damage_types = list(BURN = 42)
@@ -190,7 +190,7 @@
 	mob_hit_sound = list('sound/effects/gore/sear.ogg')
 	hitsound_wall = 'sound/weapons/guns/misc/ric4.ogg'
 	damage_types = list(BRUTE = 54)
-	armor_divisor = 4
+	armor_penetration = 8
 	check_armour = ARMOR_BULLET
 	affective_damage_range = 16
 	affective_ap_range = 16
@@ -201,7 +201,7 @@
 /obj/item/projectile/plasma/check_penetrate(var/atom/A)
 	if(istype(A, /obj/item/shield))
 		var/obj/item/shield/S = A
-		var/loss = min(round(armor_divisor * 2 / S.durability), 1)
+		var/loss = min(round(armor_penetration * 2 / S.durability), 1)
 		block_damage(loss, A)
 		A.visible_message(SPAN_WARNING("\The [src] is weakened by the \the [A]!"))
 		playsound(A.loc, 'sound/weapons/shield/shielddissipate.ogg', 50, 1)

--- a/code/modules/projectiles/projectile/plasma_aoe.dm
+++ b/code/modules/projectiles/projectile/plasma_aoe.dm
@@ -1,7 +1,7 @@
 /obj/item/projectile/plasma/aoe
 	name = "default plasma aoe"
 	icon_state = "ion"
-	armor_divisor = 1
+	armor_penetration = 1
 	damage_types = list(BURN = 0)
 
 	var/aoe_strong = 0
@@ -17,14 +17,14 @@
 		if(emp_strength)
 			empulse(target.loc, aoe_strong, aoe_weak, strength=emp_strength)
 		if(heat_damage)
-			heatwave(target.loc, aoe_strong, aoe_weak, heat_damage, fire_stacks, armor_divisor)
+			heatwave(target.loc, aoe_strong, aoe_weak, heat_damage, fire_stacks, armor_penetration)
 
 	..()
 
 /obj/item/projectile/plasma/aoe/ion
 	name = "ion-plasma bolt"
 	icon_state = "ion"
-	armor_divisor = 1
+	armor_penetration = 1
 	damage_types = list(BURN = 27)
 
 	aoe_strong = 1
@@ -37,7 +37,7 @@
 
 /obj/item/projectile/plasma/aoe/ion/light
 	name = "light ion-plasma bolt"
-	armor_divisor = 1
+	armor_penetration = 1
 	damage_types = list(BURN = 20)
 
 	aoe_strong = 0
@@ -50,7 +50,7 @@
 
 /obj/item/projectile/plasma/aoe/heat
 	name = "high-temperature plasma blast"
-	armor_divisor = 2.25
+	armor_penetration = 3
 	damage_types = list(BURN = 20)
 
 	aoe_strong = 1
@@ -63,7 +63,7 @@
 
 /obj/item/projectile/plasma/aoe/heat/strong
 	name = "high-temperature plasma blast"
-	armor_divisor = 1.25
+	armor_penetration = 2
 	damage_types = list(BURN = 33)
 
 	aoe_strong = 1

--- a/code/modules/projectiles/projectile/projectilegrenades.dm
+++ b/code/modules/projectiles/projectile/projectilegrenades.dm
@@ -3,7 +3,7 @@
 	icon_state = "grenade"
 	damage_types = list(BRUTE = 20, HALLOSS = 100)
 	check_armour = ARMOR_MELEE
-	armor_divisor = 1
+	armor_penetration = 1
 	embed = TRUE			//literally imagine being hit by this.
 	can_ricochet = TRUE		//It's rubber
 	sharp = FALSE
@@ -13,7 +13,7 @@
 	name = "grenade shell"
 	icon_state = "grenade"
 	damage_types = list(BRUTE = 10)
-	armor_divisor = 1
+	armor_penetration = 1
 	embed = TRUE
 	sharp = FALSE
 	check_armour = ARMOR_BULLET

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -37,7 +37,7 @@
 	name = "high explosive rocket"
 	icon_state = "rocket"
 	damage_types = list(BRUTE = 70)
-	armor_divisor = 10
+	armor_penetration = 10
 	check_armour = ARMOR_BULLET
 	recoil = 75
 
@@ -67,7 +67,7 @@
 	name = "EMP rocket"
 	icon_state = "rocket_e"
 	damage_types = list(BRUTE = 10, BURN = 30)
-	armor_divisor = 10
+	armor_penetration = 10
 	check_armour = ARMOR_BULLET
 	var/heavy_emp_range = 3
 	var/light_emp_range = 8
@@ -270,7 +270,7 @@
 	damage_types = list(BRUTE = 12) //Intended to be brute
 	agony = 20
 	icon_state = "declone"
-	armor_divisor = 10
+	armor_penetration = 10
 	recoil = 2
 
 /obj/item/projectile/IRKdebilitate/on_impact(atom/target)
@@ -314,7 +314,7 @@
 	icon_state = "flare"
 	damage_types = list(BURN = 12) //Legit deadlyest gun that you get in mass
 	kill_count = 12
-	armor_divisor = 1
+	armor_penetration = 1
 	step_delay = 3
 	eyeblur = 2 // bright light slightly blurs your vision
 	luminosity_range = 5
@@ -387,7 +387,7 @@
 	name = "sonic bolt"
 	icon_state = "energy2"
 	damage_types = list(BRUTE = 10)
-	armor_divisor = 3 // It is a sound-wave liquifing organs I guess
+	armor_penetration = 3 // It is a sound-wave liquifing organs I guess
 	kill_count = 7
 	check_armour = ARMOR_ENERGY
 	var/golem_damage_bonus = 20 // Damage multiplier against ameridians.
@@ -421,7 +421,7 @@
 /obj/item/projectile/tether/tail
 	name = "tail lash"
 	damage_types = list(BRUTE = 13)
-	armor_divisor = 2
+	armor_penetration = 2
 	nodamage = FALSE
 	stun = 2 //Horrors
 	weaken = 2 //Unspeakable
@@ -502,7 +502,7 @@
 /obj/item/projectile/bullet/os_trurret_gauss
 	name = "ferrous slug"
 	damage_types = list(BRUTE = 15)
-	armor_divisor = 2
+	armor_penetration = 2
 	penetrating = 2
 	recoil = 30
 	step_delay = 0.4
@@ -524,7 +524,7 @@
 	name = "plasma discharge bolt"
 	icon_state = "ice_1"
 	damage_types = list(BURN = 47)
-	armor_divisor = 2.5
+	armor_penetration = 3
 	check_armour = ARMOR_ENERGY
 	recoil = 8
 

--- a/code/modules/psionics/psionic_items/psi_temp_items.dm
+++ b/code/modules/psionics/psionic_items/psi_temp_items.dm
@@ -133,7 +133,7 @@
 	if(user.stats.getPerk(PERK_PSI_MANIA))
 		force = WEAPON_FORCE_BRUTAL
 		whack_speed = 6
-		armor_divisor = ARMOR_PEN_HALF
+		armor_penetration = ARMOR_PEN_DEADLY
 
 	var/throwdir = get_dir(user,target)
 	target.throw_at(get_edge_target_turf(target, throwdir),whack_speed,whack_speed)
@@ -191,7 +191,7 @@
 
 	if(user.stats.getPerk(PERK_PSI_MANIA))
 		force = WEAPON_FORCE_BRUTAL
-		armor_divisor = ARMOR_PEN_HALF
+		armor_penetration = ARMOR_PEN_DEADLY
 
 	..()
 	force = initial(force) // Reset the damage just in case
@@ -289,7 +289,7 @@
 
 		if(holder.stats.getPerk(PERK_PSI_MANIA))
 			force = /obj/item/projectile/kinetic_blast/brutal
-			armor_divisor = ARMOR_PEN_HALF
+			armor_penetration = ARMOR_PEN_DEADLY
 
 		projectile_type = force
 
@@ -360,7 +360,7 @@
 
 		if(holder.stats.getPerk(PERK_PSI_MANIA))
 			force = /obj/item/projectile/kinetic_blast_electro/brutal
-			armor_divisor = ARMOR_PEN_HALF
+			armor_penetration = ARMOR_PEN_DEADLY
 
 		projectile_type = force
 

--- a/modular_sojourn/fencer.dm
+++ b/modular_sojourn/fencer.dm
@@ -15,7 +15,7 @@
 
 	melee_damage_lower = 15
 	melee_damage_upper = 15
-	armor_divisor = 2
+	armor_penetration = 2
 	deathmessage = "Gives a short wave and steps forwards into nothing..."
 
 	armor = list(melee = 0, bullet = 0, energy = 0, bomb = 0, bio = 500, rad = 500, agony = 0)
@@ -93,7 +93,7 @@
 		melee_damage_lower = 15
 		melee_damage_upper = 15
 
-	armor_divisor = 2 * (coins + 1) //AP grows faster then raw damage
+	armor_penetration = 2 * (coins + 1) //AP grows faster then raw damage
 
 	if(ishuman(A))
 		var/mob/living/carbon/human/H = A

--- a/modular_sojourn/power_puncher.dm
+++ b/modular_sojourn/power_puncher.dm
@@ -112,8 +112,8 @@
 			take_damage(dmg, dmg_type)
 		if(P.agony)
 			take_damage(P.agony, HALLOSS)
-		if(P.armor_divisor)
-			take_damage(P.armor_divisor * 10, HALLOSS)
+		if(P.armor_penetration)
+			take_damage(P.armor_penetration * 10, HALLOSS)
 
 /obj/machinery/power/puncher/Destroy()
 	return ..()

--- a/nano/templates/tool_stats.tmpl
+++ b/nano/templates/tool_stats.tmpl
@@ -96,7 +96,7 @@
 			Armor penetration:
 		</div>
 		<div class="itemContent">
-			{{:data.armor_divisor}}
+			{{:data.armor_penetration}}
 		</div>
 
 		{{if data.extra_volume}}
@@ -159,7 +159,7 @@
 			{{/if}}
 		{{/if}}
 
-		{{if data.w_class > 3}} 
+		{{if data.w_class > 3}}
 			<h5>Double tact</h5>
 		{{/if}}
 	</div>

--- a/nano/templates/weapon_stats.tmpl
+++ b/nano/templates/weapon_stats.tmpl
@@ -80,7 +80,7 @@
 			Armor penetration:
 		</div>
 			<div class="itemContent">
-				{{:helper.displayBar(data.armor_divisor, 0, 100, '', data.armor_divisor + '%')}}
+				{{:helper.displayBar(data.armor_penetration, 0, 100, '', data.armor_penetration + '%')}}
 			</div>
 
 		{{if data.caliber}}

--- a/nano/templates/weapon_stats.tmpl
+++ b/nano/templates/weapon_stats.tmpl
@@ -23,7 +23,7 @@
 
 		{{if data.penetration_multiplier != 1}}
 			<div class="itemLabel">
-				Projectile Armor Divisor:
+				Projectile Armor Penetration:
 			</div>
 			<div class="itemContent">
 				{{:data.penetration_multiplier}}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Reworks armor to no longer use divisors. Instead, it utilizes full damage, and flat armor penetration. This is only a proof of concept and requires many more players to actually make projectiles balanced and feel good. Armor pen values are changed across the board to utilize values from 0-20 for armor penetration, 0 being the least and 20 being the most armor pen. Most projectiles have on average like, 1-5 armor pen or something, only the bigger bullets have higher penetration. I have not went over melee weapon values however, but most of them should be affected by the changes if they used the armor_penetration defines that were previously used by divisors. Armor Maximum is a new variable in order to prevent armor from being fully useless, allowing lower tier armors to still retain a large majority of their armor blocking capabilities by reducing at most 3 damage. This is intended to help reduce wound scale multipliers with projectiles with not only Lethals, but also High Velocities, and other special projectiles. 

`((Base Projectile Damage * Weapon Damage Projectile Multiplier) - max(armor_maximum, (Armor - Penetration Power))) * Wound Scale = Result Damage`

Please utilize this formula into multiple projectiles and see how they work with their modified values. So far it has been positive results. 

`armor_maximum = 3`, for calculation purposes I'll be sure to update this if this ever gets changed. 

On top of that, all of the projectiles have been slightly tweaked with eyeballed values to try and setup for these changes with existing armor values. 
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
