### PR TITLE
Automatically label test merges

### DIFF
--- a/.github/workflows/label_test_merges.yml
+++ b/.github/workflows/label_test_merges.yml
@@ -1,0 +1,142 @@
+# TODO: Move out code into separate scripts
+
+## Required Vars:
+# TGS_USERNAME
+# TGS_INSTANCE
+## Required Secrets:
+# TGS_PASSWORD
+# AES_KEY
+
+name: Label Test Merges
+on:
+  # pull_request:
+  #   branches:
+  #   - master
+  #   types:
+  #   - labeled
+  #   - unlabeled
+  #   - closed
+  schedule:
+    - cron: '0 * * * *'
+
+jobs:
+  update_prs_based_on_tgs:
+    # Run on schedule to check which PRs are test-merged in TGS
+    # This will (un)label the relevant PRs
+    runs-on: ubuntu-22.04
+    if: github.event_name == 'schedule'
+    steps:
+      - name: Authenticate with TGS
+        id: authenticate
+        run: |
+          response=$(curl -L -X 'POST' \
+            'https://control.bluespace.engineer/api' \
+            -H 'accept: application/json' \
+            -H 'Api: Tgstation.Server.Api/10.7.0' \
+            -H "Authorization: Basic $(echo -n "${{ vars.TGS_USERNAME }}:${{ secrets.TGS_PASSWORD }}" | base64)"
+          )
+          encrypted=$(echo "$response" | jq -r '.bearer' | openssl aes-256-cbc -a -salt -pass pass:${{ secrets.AES_KEY }})
+          echo "TGS_BEARER=$encrypted" >> "$GITHUB_OUTPUT"
+      - name: Get PRs from TGS
+        id: get_prs
+        run: |
+          bearer=$(echo ${{ steps.authenticate.outputs.bearer }} | openssl aes-256-cbc -d -a -salt -pass pass:${{ secrets.AES_KEY }})
+          response=$(curl -L -X 'GET' \
+            'https://control.bluespace.engineer/api/Repository' \
+            -H 'accept: application/json' \
+            -H 'Api: Tgstation.Server.Api/10.7.0' \
+            -H 'Instance: ${{ vars.TGS_INSTANCE }}' \
+            -H "Authorization: Bearer $bearer"
+          )
+          echo "$response" >> "$GITHUB_OUTPUT"
+      - uses: octokit/graphql-action@v2
+        name: Get PRs from GitHub
+        id: get_prs_github
+        # This action is limited to 100 open PRs, and 10 labels per PR before it starts potentially missing stuff
+        # I doubt we'll ever hit that limit, but it's worth keeping in mind
+        with:
+          query: |
+            query ($repositoryOwner: String!, $repositoryName: String!, $label: String!) {
+              repository(owner: $repositoryOwner, name: $repositoryName) {
+                pullRequests(
+                  states: OPEN
+                  first: 100
+                  orderBy: {field: UPDATED_AT, direction: DESC}
+                  labels: [$label]
+                ) {
+                  nodes {
+                    number
+                  }
+                }
+              }
+            }
+          variables: |
+            owner: ${{ github.event.repository.owner.name }}
+            repo: ${{ github.event.repository.name }}
+            label: "Testmerge"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Update PRs
+        id: update_prs
+        run: |
+          eval "github_prs=( $(echo '${{ steps.get_prs_github.outputs.data }}' | jq -r '@sh "\([.data.repository.pullRequests.nodes[].number])"') )"
+          eval "tgs_prs=( $(echo '${{ steps.get_prs.outputs.stdout }}' | jq -r '@sh "\([.revisionInformation.activeTestMerges[].number])"') )"
+
+          # Sort for unique values (This shouldn't be necessary, but it's a good idea anyway)
+          sorted_github_prs=($(printf "%s\n" "${github_prs[@]}" | sort -u))
+          sorted_tgs_prs=($(printf "%s\n" "${tgs_prs[@]}" | sort -u))
+
+          # Find which test merges are already labeled
+          intersection=($(comm -12 <(printf "%s\n" "${sorted_github_prs[@]}") <(printf "%s\n" "${sorted_tgs_prs[@]}")))
+
+          # PRs in github that are not in TGS -- Remove label
+          leftover_github=($(comm -23 <(printf "%s\n" "${sorted_github_prs[@]}") <(printf "%s\n" "${intersection[@]}")))
+
+          # PRs in TGS that are not in github -- Add label
+          leftover_tgs=($(comm -13 <(printf "%s\n" "${sorted_github_prs[@]}") <(printf "%s\n" "${intersection[@]}")))
+
+          for pr in "${leftover_github[@]}"; do
+            echo "Removing label from PR $pr"
+            curl -L -X 'DELETE' \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "https://api.github.com/repos/${{ github.event.repository.owner.name }}/${{ github.event.repository.name }}/issues/$pr/labels/Testmerge"
+          done
+
+          for pr in "${leftover_tgs[@]}"; do
+            echo "Adding label to PR $pr"
+            curl -L -X 'POST' \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              -d '{"labels":["Testmerge"]}'
+              "https://api.github.com/repos/${{ github.event.repository.owner.name }}/${{ github.event.repository.name }}/issues/$pr/labels"
+          done
+
+
+## These do nothing for now, pending discussion on whether this is wanted.
+
+  # enable_test_merge_based_on_label:
+  #   # Run when a PR is labeled with the 'test merge' label
+  #   # This will prompt TGS to test merge this PR
+  #   runs-on: ubuntu-22.04
+  #   if: |
+  #     github.event_name == 'pull_request' &&
+  #     github.event.action == 'labeled' &&
+  #     github.event.label.name == 'test merge'
+  #   steps:
+  #     - name: Do nothing
+  #       run: echo "Nothing to do"
+
+  # disable_test_merge_based_on_label:
+  #   # Run when a PR is unlabeled with the 'test merge' label
+  #   # This will prompt TGS to un-'test merge' this PR
+  #   runs-on: ubuntu-22.04
+  #   if: |
+  #     github.event_name == 'pull_request' &&
+  #     github.event.action == 'unlabeled' &&
+  #     github.event.label.name == 'test merge'
+  #   steps:
+  #     - name: Do nothing
+  #       run: echo "Nothing to do"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
> [!IMPORTANT]
> This PR has not been tested comprehensively yet by me because doing that in GitHub actions is a massive pain and I knocked this out in an afternoon between other bits of work.

<details>
<summary>
Runs a cron job that checks TGS against GH for test merges and appropriately (un)labels PRs.
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This is a new github actions workflow that runs once every hour and check TGS against GitHub to detect whether a PR has been testmerged or not, applying and removing the 'TestMerge' label as necessary.

We'll need to discuss whether we think having the workflow run once per hour is enough or whether we want to change that.
Aside from that, there's also the case of if we want to have 2-way sync (i.e. applying the label in GitHub causing the PR to get testmerged in TGS automatically.
And there's the question of if we want to fully clean up the code now or focus on just getting this out first and then do cleanup as part of a later cleanup pass for CI.
<hr>
</details>

## Changelog
:cl:WolfSkin
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
server: Added auto-labelling workflow for test merges
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
