### PR TITLE
Fix bad game design choice

### DIFF
--- a/code/datums/craft/recipes/medical.dm
+++ b/code/datums/craft/recipes/medical.dm
@@ -7,7 +7,7 @@
 	result = /obj/item/stack/medical/bruise_pack/handmade
 	icon_state = "clothing"
 	steps = list(
-		list(CRAFT_MATERIAL, 5, MATERIAL_CLOTH, "time" = 15),
+		list(CRAFT_MATERIAL, 4, MATERIAL_CLOTH, "time" = 15),
 	)
 
 /datum/craft_recipe/medical/silkointment


### PR DESCRIPTION
## About The Pull Request
There is a crafting option to create makeshift bandages from cloth. Coincidentally, there's a crafting option to create cloth out of a jumpsuit.
Now, realistically, if you're punishing the player by forcing them to get rid of their clothes to fix a wound, that should be plenty, right?
WRONG. You need ONE (1) MORE CLOTH SHEET to make bandages. GLHF.

## Changelog
:cl:
Crafting bandages now takes 4 cloth instead of 5.
/:cl: