### PR TITLE
Comment out noob names mechanics - move all noob names to alt titles

### DIFF
--- a/code/game/jobs/job/blackshield.dm
+++ b/code/game/jobs/job/blackshield.dm
@@ -182,7 +182,7 @@
 	spawn_positions = 3
 	supervisors = "the Blackshield Commander"
 	difficulty = "Hard."
-	noob_name = "Blackshield Cadet"
+	// noob_name = "Blackshield Cadet"
 	alt_titles = list("Blackshield Cadet")
 	selection_color = "#a7bbc6"
 	wage = WAGE_LABOUR_HAZARD

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -15,7 +15,7 @@
 	var/current_positions = 0				// How many players have this job
 	var/supervisors					// Supervisors, who this person answers to directly
 	var/selection_color = "#ffffff"			// Selection screen color
-	var/noob_name
+	// var/noob_name - Equinox Edit: We trust players to select the alt title themselves if they feel like they don't have enough experience
 	var/list/alt_titles
 	var/list/alt_perks
 	var/difficulty = "Null"

--- a/code/game/jobs/job/prospector.dm
+++ b/code/game/jobs/job/prospector.dm
@@ -117,7 +117,7 @@
 	spawn_positions = 2
 	supervisors = "the Foreman"
 	difficulty = "Medium."
-	noob_name = "Rookie Salvager"
+	// noob_name = "Rookie Salvager" - Equinox Edit
 	alt_titles = list("Sawbones", "Rookie Salvager")
 	//alt_perks = list("Sawbones"=list(PERK_MEDICAL_EXPERT, PERK_STALKER), "Junk Technician"=list(PERK_JUNKBORN, PERK_ROBOTICS_EXPERT))
 	selection_color = "#a7bbc6"
@@ -167,7 +167,7 @@
 	spawn_positions = 2
 	supervisors = "the Foreman"
 	difficulty = "Medium."
-	noob_name = "Rookie Prospector"
+	// noob_name = "Rookie Prospector" - Equinox Edit
 	alt_titles = list("Rookie Prospector", "Hired Muscle")
 	selection_color = "#a7bbc6"
 	initial_balance = 500	//Should be enough to get by with basic meds, tools, and food round start.

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -72,8 +72,8 @@
 	difficulty = "Medium."
 	selection_color = "#bdb1bb"
 	wage = WAGE_PROFESSIONAL
-	noob_name = "Soteria Research Student"
-	alt_titles = list("Soteria Intern","Soteria Xenobiologist", "Soteria Xenoarcheologist", "Soteria Xenobotanist", "Soteria Research Fabricator", "Soteria Geneticist")
+	// noob_name = "Soteria Research Student" - Equinox Edit
+	alt_titles = list("Soteria Research Student", "Soteria Intern", "Soteria Xenobiologist", "Soteria Xenoarcheologist", "Soteria Xenobotanist", "Soteria Research Fabricator", "Soteria Geneticist")
 	outfit_type = /decl/hierarchy/outfit/job/science/scientist
 	disallow_species = list(FORM_AGSYNTH, FORM_BSSYNTH, FORM_CHURCHSYNTH, FORM_NASHEF)
 
@@ -118,8 +118,8 @@
 	spawn_positions = 2
 	supervisors = "the Chief Research Overseer"
 	difficulty = "Medium."
-	noob_name = "Soteria Roboticist Student"
-	alt_titles = list("Robotics Lab Assistant", "Soteria Cyberneticist", "Soteria Mechanist", "Soteria Biomechanical Engineer")
+	// noob_name = "Soteria Roboticist Student" - Equinox Edit it is going into alt titles below
+	alt_titles = list("Soteria Roboticist Student", "Robotics Lab Assistant", "Soteria Cyberneticist", "Soteria Mechanist", "Soteria Biomechanical Engineer")
 	selection_color = "#bdb1bb"
 	wage = WAGE_PROFESSIONAL
 	department_account_access = TRUE

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -130,7 +130,7 @@
 	spawn_positions = 2
 	supervisors = "the Warrant Officer"
 	difficulty = "Hard."
-	noob_name = "Junior Ranger"
+	// noob_name = "Junior Ranger" - Equinox Edit it is going into alt titles below
 	alt_titles = list("Junior Ranger","Detective","Forensics Specialist")
 	selection_color = "#a7bbc6"
 	wage = WAGE_PROFESSIONAL
@@ -189,8 +189,8 @@
 	spawn_positions = 3
 	supervisors = "the Warrant Officer"
 	difficulty = "Hard."
-	noob_name = "Marshal Assistant"
-	alt_titles = list("Marshal Civil Servant")
+	// noob_name = "Marshal Assistant" - Equinox Edit it is going into alt titles below
+	alt_titles = list("Marshal Assistant", "Marshal Civil Servant")
 	selection_color = "#a7bbc6"
 	wage = WAGE_LABOUR_HAZARD
 	health_modifier = 10

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -205,7 +205,7 @@
 /datum/category_item/player_setup_item/occupation/OnTopic(href, href_list, user)
 
 	//Keeps track of the Player being looked at
-	var/client/C = usr.client
+	// var/client/C = usr.client - Equinox edit unused var
 
 	if(href_list["reset_jobs"])
 		ResetJobs()
@@ -222,14 +222,16 @@
 		var/datum/job/job = locate(href_list["select_alt_title"])
 		if (job)
 			var/choices
-			if (job.department != DEPARTMENT_LSS)
-				choices = list(job.noob_name)								// Time locks for Alt Names. Change the 0's to configure when the normal title opens up, and when the alternative ones do too.
-				if (SSjob.JobTimeAutoCheck(C.ckey, "[type]", "[job]", 0))	//<--- Change this number to establish how long a CKEY has to play a position until they're not forced a "n00b name"
-					choices += list(job.title)
-				if (SSjob.JobTimeAutoCheck(C.ckey, "[type]", "[job]", 0))	//<--- Change this number to establish how long to go from normal job name to unlocking the alternate names.
-					choices += job.alt_titles
-			else
-				choices = list(job.noob_name) + list(job.title) + job.alt_titles
+			// Equinox Edit START - Just remove the entire noob names + job title unlock system
+			// if (job.department != DEPARTMENT_LSS)
+			// 	choices = list(job.noob_name)								// Time locks for Alt Names. Change the 0's to configure when the normal title opens up, and when the alternative ones do too.
+			// 	if (SSjob.JobTimeAutoCheck(C.ckey, "[type]", "[job]", 0))	//<--- Change this number to establish how long a CKEY has to play a position until they're not forced a "n00b name"
+			// 		choices += list(job.title)
+			// 	if (SSjob.JobTimeAutoCheck(C.ckey, "[type]", "[job]", 0))	//<--- Change this number to establish how long to go from normal job name to unlocking the alternate names.
+			// 		choices += job.alt_titles
+			// else
+			// choices = list(job.noob_name) + list(job.title) + job.alt_titles
+			choices = list(job.title) + job.alt_titles
 
 			var/choice = input("Choose a title for [job.title].", "Choose Alternative Title", pref.GetPlayerAltTitle(job)) as anything in choices|null
 			if(choice && CanUseTopic(user))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Closes #102 - Remove the noob name mechanics and fix the three noob_name not covered by alt titles
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
tweak: Noob name mechanics no longer exist. Soteria Research Student (Scientist), Roboticist Student and Marshal Assistant (Officer Alt) title should work now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
