### PR TITLE
Cyborg QoL Changes and Rebalancing

### DIFF
--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -98,28 +98,33 @@
 /datum/robot_component/armour
 	name = "mark I armour plating"
 	external_type = /obj/item/robot_parts/robot_component/armour
-	max_damage = 80
+	max_damage = 100
+	burn_mult = 0.9
+	brute_mult = 0.9
 
 /datum/robot_component/armour/energy
 	name = "mark II energy armour plating"
 	external_type = /obj/item/robot_parts/robot_component/armour/mkii
-	max_damage = 120
+	max_damage = 125
 	installed_by_default = FALSE
 	burn_mult = 0.5
+	brute_mult = 0.9
 
 /datum/robot_component/armour/melee
 	name = "mark III reinforced armour plating"
 	external_type = /obj/item/robot_parts/robot_component/armour/mkiii
-	max_damage = 120
+	max_damage = 125
 	installed_by_default = FALSE
+	burn_mult = 0.9
 	brute_mult = 0.5
 
 /datum/robot_component/armour/extra
 	name = "mark V extra armour plating"
 	external_type = /obj/item/robot_parts/robot_component/armour/mkv
-	max_damage = 160 //33% more hp then other plates but no resistances.
+	max_damage = 200
 	installed_by_default = FALSE
-
+	burn_mult = 0.6
+	brute_mult = 0.6
 
 // JETPACK
 // Allows the cyborg to move in space
@@ -323,24 +328,28 @@
 	desc = "A robot part, basic metal plates to be able to take dents and burns so more sensitive component inside dont."
 	icon_state = "armor"
 	icon_state_broken = "armor_broken"
-	internal_damage = 80
+	internal_damage = 100
+	burn_mult = 0.9
+	brute_mult = 0.9
 
 /obj/item/robot_parts/robot_component/armour/mkii
 	name = "Mark II energy armour plating"
 	desc = "A robot part, metal plates designed to resist burns better then other plates. Protects other sensitive components."
 	icon_state = "armormk2"
 	icon_state_broken = "armormk2_broken"
-	internal_damage = 120
+	internal_damage = 125
 	matter = list(MATERIAL_STEEL = 25)
 	burn_mult = 0.5
+	brute_mult = 0.9
 
 /obj/item/robot_parts/robot_component/armour/mkiii
 	name = "Mark III reinforced armour plating"
 	desc = "A robot part, metal plates designed to resist a beating better then other plates. Protects other sensitive components."
 	icon_state = "armormk2"
 	icon_state_broken = "armormk2_broken"
-	internal_damage = 120
+	internal_damage = 125
 	matter = list(MATERIAL_STEEL = 25)
+	burn_mult = 0.9
 	brute_mult = 0.5
 
 /obj/item/robot_parts/robot_component/armour/mkv
@@ -348,8 +357,10 @@
 	desc = "A robot part, whats better then a few metal plates? MORE metal plates! Protects other sensitive components."
 	icon_state = "armormk5"
 	icon_state_broken = "armormk5_broken"
-	internal_damage = 160
+	internal_damage = 200
 	matter = list(MATERIAL_STEEL = 20, MATERIAL_PLASTEEL = 10)
+	burn_mult = 0.6
+	brute_mult = 0.6
 
 /obj/item/robot_parts/robot_component/camera
 	name = "camera"

--- a/code/modules/mob/living/silicon/robot/robot_damage.dm
+++ b/code/modules/mob/living/silicon/robot/robot_damage.dm
@@ -155,13 +155,12 @@
 
 
 /mob/living/silicon/robot/get_fall_damage(var/turf/from, var/turf/dest)
-	//Robots should not be falling! Their bulky inarticulate frames lack shock absorbers, and gravity turns their armor plating against them
-	//Falling down a floor is extremely painful for robots, and for anything under them, including the floor
+	//Falling down a floor is painful for robots, and for anything under them, including the floor
 
-	var/damage = maxHealth*0.49 //Just under half of their health
+	var/damage = maxHealth*0.10 //10% health
 	//A percentage is used here to simulate different robots having different masses. The bigger they are, the harder they fall
 
-	//Falling two floors is not an instakill, but it almost is
+	//Falling more floors deals more damage
 	if (from && dest)
 		damage *= abs(from.z - dest.z)
 
@@ -172,7 +171,7 @@
 /mob/living/silicon/robot/fall_impact(var/turf/from, var/turf/dest)
 	take_overall_damage(get_fall_damage(from, dest))
 
-	Stun(5)
+	Stun(2)
 	updatehealth()
 	//Wreck the contents of the tile
 	for (var/atom/movable/AM in dest)

--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -423,6 +423,8 @@
 	degradation = 0
 	sharp = 1
 	embed_mult = 0
+	max_health = 9999999 // Workaround to prevent borgtools from permanently breaking once upgrades are applied
+	workspeed = 1.25	// Better parity with regular crew
 
 /obj/item/tool/robotic_omni/surgery
 	name = "Surgery omni tool"
@@ -489,8 +491,8 @@
 						  QUALITY_DIGGING = 40)
 
 /obj/item/tool/robotic_omni/cleaner
-	name = "Borrow Omni tool"
-	desc = "Omni tool for Janitor borgs, mostly just for cutting up body and clearing borrows."
+	name = "Burrow Omni tool"
+	desc = "Omni tool for Janitor borgs, mostly just for cutting up body and clearing burrows."
 	icon_state = "engimplant"
 	tool_qualities = list(QUALITY_PRYING = 20,
 						  QUALITY_HAMMERING = 35, //For undoing random things like barrer placements

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -56,7 +56,7 @@ var/global/list/robot_modules = list(
 	// A list of robot traits , these can be found at cyborg_traits.dm
 	var/robot_traits = null
 	//Module stats, these are applied to the robot
-	health = 100 //Max health. Apparently this is already defined in item.dm
+	health = 200 //Max health. Apparently this is already defined in item.dm
 	var/speed_factor = 1.3 //Speed factor, applied as a divisor on movement delay
 	var/power_efficiency = 1.0 //Power efficiency, applied as a divisor on power taken from the internal cell
 
@@ -393,9 +393,9 @@ var/global/list/robot_modules = list(
 
 /obj/item/robot_module/medical/general
 	name = "medical robot module"
-	health = 120 //bit weaker
+	health = 240 //bit weaker
 	speed_factor = 1.3 //normal speed
-	power_efficiency = 0.9 //Very poor, shackled to a charger
+	power_efficiency = 1.0
 	supported_upgrades = list(/obj/item/borg/upgrade/hypospray_medical,
 							  /obj/item/borg/upgrade/jetpack)
 
@@ -540,9 +540,9 @@ var/global/list/robot_modules = list(
 				"dullahancargo"
 				)
 
-	health = 120 //Slightly above average
+	health = 240 //Slightly above average
 	speed_factor = 1.4 //Slightly above average
-	power_efficiency = 0.9 //Slightly below average
+	power_efficiency = 1.0
 
 	desc = "The engineering module is designed for setting up and maintaining core colony systems, \
 	as well as occasional repair work here and there. It's a good all rounder that can serve most \
@@ -685,9 +685,9 @@ var/global/list/robot_modules = list(
 							 /obj/item/borg/upgrade/bigknife)
 
 /obj/item/robot_module/security/defense
-	health = 160 //Kinda light! We're meant for rapid response
+	health = 320 //Kinda light! We're meant for rapid response
 	speed_factor = 1.45 //pretty fast!
-	power_efficiency = 0.95 //We're dangerous, but generally can't stray too far from our chargers!
+	power_efficiency = 1.0
 
 	desc = "Focused on protecting the colony from great threats! Ensure a rapid response to any  major threats, leave little stuff to the humans and enforcement bots \
 	heavily armed, though lightly armored security unit."
@@ -774,9 +774,9 @@ var/global/list/robot_modules = list(
 
 
 /obj/item/robot_module/security/enforcement
-	health = 220 //Very tanky!
+	health = 440 //Very tanky!
 	speed_factor = 1.15 //Kinda slow
-	power_efficiency = 1.55 //Decent, we are meant to be going out and learing spiders
+	power_efficiency = 1.0
 
 	desc = "Focused on keeping the peace and ensuring colony law is maintained, the enforcement module is a \
 	heavily armored, though lightly armed security unit."
@@ -918,9 +918,9 @@ var/global/list/robot_modules = list(
 					"dullahanjani"
 				)
 
-	health = 120 //Bulky
+	health = 240 //Bulky
 	speed_factor = 1.45 //Fast
-	power_efficiency = 0.8 //Poor
+	power_efficiency = 1.0
 
 	supported_upgrades = list(/obj/item/borg/upgrade/jetpack,
 							  /obj/item/borg/upgrade/satchel_of_holding_for_borgs)
@@ -1018,7 +1018,7 @@ var/global/list/robot_modules = list(
 					"dullahanserv_alt"
 				)
 
-	health = 120
+	health = 240
 	speed_factor = 1.5 //Quick
 	power_efficiency = 1 //Base line
 
@@ -1129,7 +1129,7 @@ var/global/list/robot_modules = list(
 					"dullahanmine"
 				)
 
-	health = 160 //Pretty tough
+	health = 320 //Pretty tough
 	speed_factor = 1.2 //meh
 	power_efficiency = 1.5 //Best efficiency
 
@@ -1210,9 +1210,9 @@ var/global/list/robot_modules = list(
 					"dullahansci"
 					)
 
-	health = 120 //Weak
+	health = 240 //Weak
 	speed_factor = 1.3 //Average
-	power_efficiency = 0.75 //Poor efficiency
+	power_efficiency = 1.0
 
 	desc = "Built for working in a well-equipped lab, and designed to handle a wide variety of research \
 	duties, this module prioritises flexibility over efficiency. Capable of working in R&D, Toxins, \
@@ -1280,7 +1280,7 @@ var/global/list/robot_modules = list(
 	no_slip = 1
 	networks = list(NETWORK_ENGINEERING)
 	channels = list("Engineering" = 1, "Common" = 1)
-	health = 35 //Basic colony drones and the like should have 35 health as they are not meant for combat
+	health = 100
 	stat_modifiers = list(
 		STAT_COG = 120,
 		STAT_MEC = 80
@@ -1385,7 +1385,7 @@ var/global/list/robot_modules = list(
 /obj/item/robot_module/drone/construction
 	name = "construction drone module"
 	channels = list("Engineering" = 1)
-	health = 75 //These spawn in high combat areas and zones, 1 shot by a random person mob isnt fun
+	health = 150
 	languages = list()
 
 /obj/item/robot_module/drone/construction/New(var/mob/living/silicon/robot/R)

--- a/code/modules/projectiles/guns/energy/misc/robotguns.dm
+++ b/code/modules/projectiles/guns/energy/misc/robotguns.dm
@@ -33,7 +33,7 @@
 	cell_type = /obj/item/cell/medium/greyson
 	modifystate = null
 	force = WEAPON_FORCE_PAINFUL
-	charge_cost = 80 //about 20 rounds per full charge
+	charge_cost = 32 //about 50 rounds per full charge
 	self_recharge = 1
 	charge_meter = TRUE
 	serial_type = "NM"
@@ -71,7 +71,7 @@
 	item_state = "glock"
 	cell_type = /obj/item/cell/medium/greyson
 	modifystate = null
-	charge_cost = 100
+	charge_cost = 50 //32 shots
 	self_recharge = 1
 	init_firemodes = list(
 		list(mode_name="rubber bullet", projectile_type=/obj/item/projectile/bullet/pistol_35/rubber, fire_sound = 'sound/weapons/guns/fire/9mm_pistol.ogg', fire_delay=10
@@ -87,7 +87,7 @@
 	name = "embedded energy SMG"
 	desc = "An energy-based SMG deployed from your arm. A favoured hidden weapon."
 	cell_type = /obj/item/cell/medium/greyson
-	charge_cost = 25
+	charge_cost = 20 //80 shots
 	self_recharge = 1
 	fire_sound = 'sound/weapons/energy/laser_pistol.ogg'
 	projectile_type = /obj/item/projectile/bullet/pistol_35/lethal //self defense gun, great for bugs less good for a "real fight" against anyone with anything resembling armor


### PR DESCRIPTION
## About The Pull Request
Cyborgs are pitifully weak in the current state of the game, with most humans being able to outperform them within minutes of a round starting. They are also extremely reliant on roboticists to improve themselves, or even just get themselves patched up. This makes playing a cyborg, especially in lower pop rounds, tedious and unfun.

This PR aims to tweak some numbers here and there to make playing a cyborg more enjoyable, without outright making them overpowered. Their health in general has been doubled, power efficiencies are 1.0 at minimum, basic armor now has 10% damage resist and won't break as easily, stronger armors have been buffed with more damage resistances, their omnitools are slightly faster and won't break as easily when upgraded, and their guns have been given some extra magazine size.

## Changelog
:cl:
balance: rebalanced borgs to be more fun to play
/:cl: