### PR TITLE
Supermajority vote + explanation for end shift vote

### DIFF
--- a/code/controllers/subsystems/voting/poll_types.dm
+++ b/code/controllers/subsystems/voting/poll_types.dm
@@ -7,9 +7,12 @@
 	name = "End Round"
 	question = "End Shift?"
 	time = 90
-	choice_types = list(/datum/vote_choice/restart, /datum/vote_choice/countinue_round)
+	minimum_win_percentage = 0.6
+	choice_types = list(/datum/vote_choice/restart, /datum/vote_choice/continue_round)
 	next_vote = 150 MINUTES //Minimum round length before it can be called for the first time
-	cooldown = 15 MINUTES //Cooldown is set to 15 mins as 1 hour is a bit much when things change so much in so little time + maxium 8 hour rounds means we should be a bit more forgiven.
+	cooldown = 15 MINUTES //Cooldown is set to 15 mins as 1 hour is a bit much when things change so much in so little time + maximum 8 hour rounds means we should be a bit more forgiving.
+	description = "You'll have 1.2 voting power if you're a head of staff or an antag, 0.6 if you're observing, dead, mouse / drone or joined for less than 15 minutes and 1 vote weight otherwise"
+
 
 	// Overriden by implementation of IsAdminOnly
 	//only_admin = TRUE
@@ -84,7 +87,7 @@
 /datum/vote_choice/restart/on_win()
 	SSticker.shift_end(15 MINUTES)
 
-/datum/vote_choice/countinue_round
+/datum/vote_choice/continue_round
 	text = "Continue Shift"
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Change the minimum winning percentage to 60% for the end shift vote (Like the evacuate vote). 

Also add in description with the exact vote weight based on what kind of criteria so that people has transparent knowledge about vote weight and where 1.2 votes come from - should make people less upset about the results of their vote without having to code dive to gain knowledge.

Fix typo

## Changelog
:cl:
tweak: End shift vote now requires 60% majority for the winning option and come with explanation on your vote weight.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
