### PR TITLE
One line fix to make LOOC stop popping up the chat bubble

### DIFF
--- a/code/modules/tgui_input/say_modal/modal.dm
+++ b/code/modules/tgui_input/say_modal/modal.dm
@@ -86,7 +86,7 @@
 	if(!payload?["channel"])
 		CRASH("No channel provided to an open TGUI-Say")
 	window_open = TRUE
-	if(payload["channel"] != OOC_CHANNEL && payload["channel"] != ADMIN_CHANNEL)
+	if(payload["channel"] != OOC_CHANNEL && payload["channel"] != LOOC_CHANNEL && payload["channel"] != ADMIN_CHANNEL)
 		start_thinking()
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request
Currently, in Hotkey mode, when you press O to type in OOC, there is no typing indicator popping up on your mob. However, when you press L to type in LOOC, a typing indicator pops up.

This PR simply makes it so that LOOC will not cause a typing indicator to appear.

## Changelog
:cl:
fix: LOOC should no longer cause a typing indicator to appear on your character.
/:cl:
