### PR TITLE
Orebox UI improvement

### DIFF
--- a/tgui/packages/tgui/interfaces/OreBox.tsx
+++ b/tgui/packages/tgui/interfaces/OreBox.tsx
@@ -19,8 +19,14 @@ export const OreBox = props => {
   const { act, data } = useBackend<Data>();
   const { materials } = data;
 
+  materials.sort((a, b) => {
+    if (a.name < b.name) { return -1 }
+    if (a.name > b.name) { return 1 }
+    return 0;
+  })
+
   return (
-    <Window width={460} height={265}>
+    <Window width={600} height={265}>
       <Window.Content>
         <Section
           fill
@@ -97,13 +103,17 @@ const OreRow = props => {
             step={1}
             stepPixelSize={5}
             minValue={1}
-            maxValue={100}
+            maxValue={600}
             value={amount}
             onChange={value => setAmount(value)}
           />
           <Button
             content='Eject Amount'
             onClick={() => onRelease(material.type, amount)}
+          />
+          <Button
+            content='Eject 120'
+            onClick={() => onRelease(material.type, 120)}
           />
           <Button
             content='Eject All'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
OreBox max ejection amount to 600, add eject 120 full stack shortcut,…widen window to 600 px to fit it in

## Changelog
:cl:
tweak: Orebox can accept custom ejection amount up to 600 (5 stacks), has a eject 120 (full stack) short cut, has a wider window and now sorts the minerals to minimize unnecessary UI shift when you eject any ores from it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
