### PR TITLE
Crafting step is no longer globally shared 

### DIFF
--- a/code/datums/craft/recipe.dm
+++ b/code/datums/craft/recipe.dm
@@ -42,13 +42,13 @@
 
 	data["name"] = name
 	data["ref"] = "[REF(src)]"
-	
+
 	// because of course we have recipes that don't produce anything
 	data["icon"] = null
 	if(result)
 		var/datum/asset/spritesheet/crafting/sprite = get_asset_datum(/datum/asset/spritesheet/crafting)
 		data["icon"] = sprite.icon_class_name(sanitize_css_class_name("[result]"))
-		
+
 	data["batch"] = flags & CRAFT_BATCH
 
 	var/atom/A = result
@@ -97,7 +97,7 @@
 	if(!can_build(user, get_turf(target)))
 		return FALSE
 	var/datum/craft_step/CS = steps[step]
-	return CS.apply(I, user, target, src)
+	return CS.apply(I, user, target, src, step + 1)
 
 /datum/craft_recipe/proc/build_batch(mob/living/user, amount)
 	if(!amount)
@@ -134,7 +134,7 @@
 	if(ishuman(user) && !I.is_held())
 		to_chat(user, SPAN_WARNING("You should hold [I] in hands for doing that!"))
 		return
-	var/apply_type = CS.apply(I, user, null, src)
+	var/apply_type = CS.apply(I, user, null, src, 0)
 	if(!apply_type)
 		return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Closes #122. This is an issue that is also in Eris code because of how the building variable works. 

The building variable is on the **global** crafting step, meaning that anyone doing one step will block **everyone** globally from doing that step.

This changes it by removing the variable and making it so that apply simply change the target - if it exists, in question's step to the target step. It also adds a safety check when target exists to avoid redundantly applying the same step. 

As a side effect, this means mass crafting is also possible by the same person on the same recipe. If this is abused to a point that it affects server performance or leave junk items - I'll consider adding in a per mob maximum check of do after or something like that.

## Changelog
:cl:
fix: Crafting one step on the server no longer blocks the entire step on the entire server.
tweak: Above also means the same person can craft the same item multiple time. Do not abuse this.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
