### PR TITLE
Prevents maxhealth reduction on level up

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1332,8 +1332,9 @@ mob/proc/yank_out_object()
 
 /mob/proc/give_health_via_stats()
 	if(maxHealth && stats)
-		health += src.stats.getStat(STAT_ANA)
-		maxHealth += src.stats.getStat(STAT_ANA)
-		if(maxHealth > 300) //soft cap to keep players from becoming killable only by organ damage or pain.
-			health = 300
-			maxHealth = 300
+		if(!(src.stats.getStat(STAT_ANA) < 0))	//If a player has negative ANA we don't want them losing health when they focus on an oddity.
+			health += src.stats.getStat(STAT_ANA)
+			maxHealth += src.stats.getStat(STAT_ANA)
+			if(maxHealth > 300) //soft cap to keep players from becoming killable only by organ damage or pain.
+				health = 300
+				maxHealth = 300


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Adds a check to make it such that players can't remove health from their stats on level up. get_health_from_stats previously didn't care if your anatomy was negative, so for example, someone who had -5 Anatomy (ANA) would lose 5 health on spawn and each time they leveled up. This is *really bad* because it means that if someone had -5 ANA they'd have 95 health, then 90, 85... If their max health was reduced to 0 this would fuck with a LOT of stuff.

This retains the balance of having negative ANA because while you don't *lose* health, you'll also never *gain* health from leveling up unless you seriously powerlevel ANA, and STAT_ANA is already not present on any oddities not made by the engineering cube, so we don't need to worry about powerleveling or powernerfing health here.
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
tweak: Prevents negative ANA from reducing max health on level up
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
