### PR TITLE
Buff ore sonar to 5 minutes. Remove reference

### DIFF
--- a/code/modules/mining/drilling/ore_sonar.dm
+++ b/code/modules/mining/drilling/ore_sonar.dm
@@ -1,6 +1,6 @@
 /obj/item/device/ore_sonar
 	name = "ore sonar"
-	desc = "A solid and robust looking white device made to work in the toughest conditions. It's able to scan and print a readout of the local ore heatmap. It works off an internal battery that takes a very long time to recharge. A droopy eared rabbit shape is stamped onto its side."
+	desc = "A solid and robust looking white device made to work in the toughest conditions. It's able to scan and print a readout of the local ore heatmap. It works off an internal battery that takes a while to recharge."
 	icon_state = "ore-sonar"
 	item_state = "ore-sonar"
 	slot_flags = SLOT_BELT
@@ -11,9 +11,9 @@
 
 /obj/item/device/ore_sonar/attack_self(mob/living/carbon/user as mob)
 	if(world.time < cooldowntime)
-		to_chat(user, SPAN_NOTICE("Device is still recharging. Please allow 20 minutes between each use, babe."))
+		to_chat(user, SPAN_NOTICE("Device is still recharging. Please allow 5 minutes between each use."))
 		return
-	cooldowntime = world.time + 20 MINUTES
+	cooldowntime = world.time + 5 MINUTES
 	to_chat(user, SPAN_NOTICE("Scan Initated. Starting to print out results."))
 	var/turf/origin = get_turf(user)
 	var/dist_scan_x = world.maxx-TRANSITIONEDGE - origin.x


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Buff ore scanner duration to 5 minutes instead of 20 minutes. Remove (likely) reference to a character that isn't in here.

## Changelog
:cl:
tweak: Ore Sonar cooldown duration changed to 5 minutes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
