### PR TITLE
Introspective and Anomaly Hunter gives exact stats and perks on oddity

### DIFF
--- a/code/datums/mob_stats.dm
+++ b/code/datums/mob_stats.dm
@@ -142,6 +142,13 @@
 	if(path)
 		return locate(path) in perks
 
+/datum/stat_holder/proc/getHasOneOfPerks(perkArray)
+	for(var/perkType in perkArray)
+		var/hasPerk = getPerk(perkType)
+		if(hasPerk)
+			return TRUE
+	return FALSE
+
 /// The main, public proc to add a perk to a mob. Accepts a path or a stringified path.
 /datum/stat_holder/proc/addPerk(perkType)
 	. = FALSE

--- a/code/modules/sanity/inspiration_component.dm
+++ b/code/modules/sanity/inspiration_component.dm
@@ -40,7 +40,7 @@
 	RegisterSignal(parent, COMSIG_EXAMINE, PROC_REF(on_examine))
 
 /datum/component/inspiration/proc/on_examine(mob/user)
-	for(var/stat  in stats)
+	for(var/stat in stats)
 		var/aspect
 		var/stat_noun
 		var/stat_adjective
@@ -120,7 +120,9 @@
 					aspect = pick(adjectives_weak)
 			else
 				continue
-		if(aspect_noun_or_adjective == "noun")
+		if(usr.stats?.getHasOneOfPerks(list(PERK_STALKER, PERK_NO_OBFUSCATION)))
+			message = "It would increase your [stat] by [stats[stat]]."
+		else if(aspect_noun_or_adjective == "noun")
 			message = pick(\
 			"This item has [a_or_an] [stat_color][aspect]</span> aspect of [stat_noun]",\
 			"Aura of [stat_color][aspect]</span> [stat_noun] pertains to it")
@@ -131,14 +133,13 @@
 			"It [stat_color][aspect]</span> reminds you of [stat_noun]", \
 			"It makes you feel [stat_color][aspect]</span> [stat_adjective]", \
 			"This feels like it might make you [stat_color][aspect]</span> [stat_adjective]", \
-			//"[stat_color][aspect]</span> [stat_adjective]."
 			)
 		if(message)
 			to_chat(user, SPAN_NOTICE(message))
 
 	if(perk)
 		to_chat(user, SPAN_NOTICE("<span style='color:orange'>A strange aura comes from this oddity, it is more than just a curio, its an anomaly...</span>"))
-		if(usr.stats?.getPerk(PERK_STALKER))
+		if(usr.stats?.getHasOneOfPerks(list(PERK_STALKER, PERK_NO_OBFUSCATION)))
 			var/datum/perk/oddity/OD = GLOB.all_perks[perk]
 			to_chat(user, SPAN_NOTICE("Instinct tells you more about this anomaly: <span style='color:orange'>[OD]. [OD.desc]</span>"))
 
@@ -149,15 +150,15 @@
 	var/strength
 	switch(get_power())
 		if(1)
-			strength = "a weak mechanical catalyst power"
+			strength = "a weak mechanical catalyst power."
 		if(2)
-			strength = "a normal mechanical catalyst power"
+			strength = "a normal mechanical catalyst power."
 		if(3)
-			strength = "a medium mechanical catalyst power"
+			strength = "a medium mechanical catalyst power."
 		if(4)
-			strength = "a strong mechanical catalyst power"
+			strength = "a strong mechanical catalyst power."
 		else
-			strength = "no catalyst power"
+			strength = "no catalyst power."
 	to_chat(user, SPAN_NOTICE("This item has [strength]"))
 
 /// Returns stats if defined, otherwise it returns the return value of get_stats


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Introspective and Anomaly Hunter gives the exact stats (You will level up by, per inspiration) and the perk you get from an oddity. The initial request was for introspective, but Anomaly Hunter should be able to serve the same function too since it is the Prospie / Salvager exclusive perk.

## Changelog
:cl:
tweak: Introspective and Anomaly Hunter now shows how much an oddity level you up by exactly, per inspiration, and the exact perk you'll get.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
