### PR TITLE
Removes forced species name. Add true species to operating computer, …

### DIFF
--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -229,6 +229,7 @@
 		"name" = H.get_visible_name(),
 		"stationtime" = stationtime2text(),
 		"stat" = H.stat,
+		"species" = H.species,
 		"health" = round(H.health / H.maxHealth * 100),
 		"bruteloss" = H.getBruteLoss(),
 		"fireloss" = H.getFireLoss(),
@@ -260,6 +261,7 @@
 	var/dat = "<font color='blue'><b>Scan performed at [occ["stationtime"]]</b></font><br>"
 	dat += "<font color='blue'><b>Occupant Statistics:</b></font><br>"
 	dat += text("ID Name: <i>[]</i><br>", occ["name"])
+	dat += text("Biological Form: <i>[]</i><br>", occ["species"])
 	var/aux
 	switch (occ["stat"])
 		if(0)

--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -52,6 +52,7 @@
 				<B>Name:</B> [victim.real_name]<BR>
 				<B>Age:</B> [victim.age]<BR>
 				<B>Blood Type:</B> [victim.b_type]<BR>
+				<B>Biological Form:</B> [victim.species]<BR>
 				<BR>
 				<B>Critical Health:</B> [victim.health]%<BR>
 				<B>Organ Health:</B> [internal_health]%<BR>

--- a/code/game/objects/items/devices/scanners/health.dm
+++ b/code/game/objects/items/devices/scanners/health.dm
@@ -144,7 +144,9 @@
 		dat += "<h2>Analyzing Results for [M]:</h2>"
 		dat += span("highlight", "Overall Status: dead")
 	else
-		dat += span("highlight", "Analyzing Results for [M]:\n\t Overall Status: [M.stat > 1 ? "dead" : "[percentage_health]% healthy"]")
+		dat += span("highlight", "Analyzing Results for [M]:")
+		dat += span("highlight", "Overall Status: [M.stat > 1 ? "dead" : "[percentage_health]% healthy"]")
+	dat += span("highlight", "Biological Form: [M.species]")
 	dat += span("highlight", "    Key: <font color='#0080ff'>Suffocation</font>/<font color='green'>Toxin</font>/<font color='red'>Brute</font>/<font color='#FFA500'>Burns</font>")
 	dat += span("highlight", "    Damage Specifics: <font color='#0080ff'>[OX]</font> - <font color='green'>[TX]</font> - <font color='red'>[BR]</font> - <font color='#FFA500'>[BU]</font>")
 	if(M.bodytemperature >= 313.15) // 40º C / 104 F = fever

--- a/code/modules/client/preference_setup/general/01_basic.dm
+++ b/code/modules/client/preference_setup/general/01_basic.dm
@@ -49,10 +49,6 @@
 /datum/category_item/player_setup_item/physical/basic/sanitize_character()
 	var/datum/species/S = all_species[pref.species ? pref.species : SPECIES_HUMAN]
 	if(!S) S = all_species[SPECIES_HUMAN]
-	if(S.obligate_name)
-		pref.custom_species = S.name
-		pref.species_aan = S.aan
-		pref.species_color = S.light_color
 	pref.age                = sanitize_integer(pref.age, S.min_age, S.max_age, initial(pref.age))
 	pref.b_type				= sanitize_text(pref.b_type, initial(pref.b_type))
 	pref.disabilities		= sanitize_integer(pref.disabilities, 0, 65535, initial(pref.disabilities))
@@ -97,8 +93,6 @@
 				pref.real_name = random_name(pref.gender, pref.species)
 	*/
 /datum/category_item/player_setup_item/physical/basic/content()
-	if(global.all_species[pref.species]?:obligate_name)
-		pref.custom_species = global.all_species[pref.species]
 	if ((pref.species == "Human") && (pref.custom_species in global.all_species))
 		pref.custom_species = "Human"
 
@@ -189,8 +183,6 @@
 		return TOPIC_REFRESH
 
 	else if(href_list["species_name"])
-		if(global.all_species[pref.species]?:obligate_name)
-			return TOPIC_NOACTION
 		var/new_species_name = input(user, "Choose your character's species name. This is cosmetic.") as text|null
 		if(CanUseTopic(user))
 			new_species_name = sanitizeName(new_species_name)
@@ -201,14 +193,10 @@
 				to_chat(user, SPAN_WARNING("Invalid species name. Either it's a single character, or more than [MAX_NAME_LEN] characters long. Aside from letters, it can only contain _, ' and ."))
 				return TOPIC_NOACTION
 	else if(href_list["species_aan"])
-		if(global.all_species[pref.species]?:obligate_name)
-			return TOPIC_NOACTION
 		if(CanUseTopic(user))
 			pref.species_aan = pref.species_aan == "n" ? "" : "n"
 			return TOPIC_REFRESH
 	else if(href_list["species_name_color"])
-		if(global.all_species[pref.species]?:obligate_name)
-			return TOPIC_NOACTION
 		var/new_color = input(user, "Choose your species name's color. This should be shared with others using that species if you propagate it.", CHARACTER_PREFERENCE_INPUT_TITLE, pref.species_color) as color|null
 		if(new_color && CanUseTopic(user))
 			var/adjusted = FALSE

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -14,7 +14,6 @@
 
 	var/default_form = FORM_HUMAN	//If nothing else sets it, what do we look like.
 	var/obligate_form = FALSE		//If true, character creation will force the use of either this form or its subforms.
-	var/obligate_name = TRUE		//If true, forces the character's species name and name color to conform.
 
 	var/list/permitted_ears  = null
 	var/list/permitted_tail  = null

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -2,7 +2,6 @@
 	name = "Human"
 	name_plural = "Humans"
 	default_form = FORM_HUMAN
-	obligate_name = FALSE
 	unarmed_types = list(/datum/unarmed_attack/punch, /datum/unarmed_attack/stomp,  /datum/unarmed_attack/kick, /datum/unarmed_attack/bite)
 	blurb = "Humanity originated in the Sol system, and over the last five centuries has spread \
 	colonies across a wide swathe of space. They hold a wide range of forms and creeds.<br/><br/> \
@@ -39,7 +38,6 @@
 	name = "Exalt Human"
 	name_plural = "Exalt Humans"
 	default_form = FORM_EXALT_HUMAN
-	obligate_name = FALSE
 	unarmed_types = list(/datum/unarmed_attack/punch, /datum/unarmed_attack/stomp,  /datum/unarmed_attack/kick, /datum/unarmed_attack/bite)
 	blurb = "Since its inception, Humankind has always sought to become something beyond itself- Exalts were their answer. Starting with baseline human DNA, \
 	an Exalt's genetic code has been tweaked to make them healthier, smarter, and stronger. Their metabolism is modified to predispose them towards staying \
@@ -600,7 +598,6 @@
 	name = "Folken"
 	name_plural = "Folkens"
 	default_form = FORM_FOLKEN
-	obligate_name = TRUE
 	obligate_form = TRUE
 	reagent_tag = IS_TREE
 	unarmed_types = list(/datum/unarmed_attack/punch, /datum/unarmed_attack/stomp,  /datum/unarmed_attack/kick, /datum/unarmed_attack/bite)
@@ -650,7 +647,6 @@
 	name = "Mycus"
 	name_plural = "Myci"
 	default_form = FORM_MYCUS
-	obligate_name = TRUE
 	obligate_form = TRUE
 	reagent_tag = IS_TREE
 	unarmed_types = list(/datum/unarmed_attack/punch/hammer_fist, /datum/unarmed_attack/stomp,  /datum/unarmed_attack/kick, /datum/unarmed_attack/bite)
@@ -702,7 +698,6 @@
 	name = "Full Body Prosthetic"
 	default_form = FORM_FBP
 	obligate_form = TRUE
-	obligate_name = FALSE
 	name_plural = "FBPs"
 	unarmed_types = list(/datum/unarmed_attack/punch, /datum/unarmed_attack/stomp,  /datum/unarmed_attack/kick, /datum/unarmed_attack/bite)
 	blurb = "no."
@@ -753,7 +748,6 @@
 	name = "Unbranded Full Body Prosthetic"
 	default_form = FORM_UNBRANDED
 	obligate_form = TRUE
-	obligate_name = FALSE
 	name_plural = "FBPs"
 	unarmed_types = list(/datum/unarmed_attack/punch, /datum/unarmed_attack/stomp,  /datum/unarmed_attack/kick, /datum/unarmed_attack/bite)
 	blurb = "no"
@@ -804,7 +798,6 @@
 	name = "Soteria Synthetic"
 	name_plural = "synthetics"
 	default_form = FORM_SOTSYNTH
-	obligate_name = TRUE
 	obligate_form = TRUE
 	unarmed_types = list(/datum/unarmed_attack/punch, /datum/unarmed_attack/stomp,  /datum/unarmed_attack/kick, /datum/unarmed_attack/bite)
 	blurb = "no."
@@ -868,7 +861,6 @@
 	name = "Artificer Guild Synthetic"
 	name_plural = "synthetics"
 	default_form = FORM_AGSYNTH
-	obligate_name = TRUE
 	obligate_form = TRUE
 	unarmed_types = list(/datum/unarmed_attack/punch, /datum/unarmed_attack/stomp,  /datum/unarmed_attack/kick, /datum/unarmed_attack/bite)
 	blurb = "no."
@@ -931,7 +923,6 @@
 	name = "Blackshield Synthetic"
 	name_plural = "synthetics"
 	default_form = FORM_BSSYNTH
-	obligate_name = TRUE
 	obligate_form = TRUE
 	unarmed_types = list(/datum/unarmed_attack/punch, /datum/unarmed_attack/stomp,  /datum/unarmed_attack/kick, /datum/unarmed_attack/bite)
 	blurb = "no."
@@ -992,7 +983,6 @@
 	name = "Absolute Synthetic"
 	name_plural = "synthetics"
 	default_form = FORM_CHURCHSYNTH
-	obligate_name = TRUE
 	obligate_form = TRUE
 	unarmed_types = list(/datum/unarmed_attack/punch, /datum/unarmed_attack/stomp,  /datum/unarmed_attack/kick, /datum/unarmed_attack/bite)
 	blurb = "no."
@@ -1054,7 +1044,6 @@
 	name = "Nashef-Agunabi"
 	name_plural = "synthetics"
 	default_form = FORM_NASHEF
-	obligate_name = TRUE
 	obligate_form = TRUE
 	unarmed_types = list(/datum/unarmed_attack/punch, /datum/unarmed_attack/stomp,  /datum/unarmed_attack/kick, /datum/unarmed_attack/bite)
 	blurb = "no."


### PR DESCRIPTION
…scanner and body scanner

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
All species can now get custom species name. To make sure medical don't malpractice people by accident while retaining the aesthetics of custom species, health scanner, operating computer and body scanner now display the **true**, non-custom species of the person

Also improve the UI of health scanner slightly by moving status to a new line which seems to have been intended but /n /t did not work.

Affects character creation, should be merged in.

![image](https://github.com/user-attachments/assets/9a5e1ca4-f99e-4f9b-a1ad-e0c652d9bc73)
![image](https://github.com/user-attachments/assets/afb3a208-e221-4ec7-8544-2d800f0b2466)
![dreamseeker_ARKmRoHUNW](https://github.com/user-attachments/assets/fc469da0-5c3d-4da7-a598-8e49dc17ca1b)

## Changelog
:cl:
tweak: All species can now have custom names. This includes all synthetics, aulvae, mycus, folken etc. 
tweak: Health Scanner, Operating Computer & Body Scanner now display the true, mechanical species of its target
tweak: Health Scanner now displays 100% Healthy or status on a separate new line.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
