### PR TITLE
Let slimes get markings - make markings transparent

### DIFF
--- a/code/modules/client/preference_setup/general/06_furry.dm
+++ b/code/modules/client/preference_setup/general/06_furry.dm
@@ -166,11 +166,10 @@ datum/preferences
 				pref.wings_colors[colornum] = color
 			return TOPIC_REFRESH_UPDATE_PREVIEW
 	if(href_list["marking_add"])
-		if(cspecies.type != /datum/species/slime)
-			var/new_marking = input(user, "Choose a marking to add:", CHARACTER_PREFERENCE_INPUT_TITLE, null) as null|anything in GLOB.body_marking_list - pref.body_markings
-			if(new_marking && CanUseTopic(user))
-				pref.body_markings[new_marking] = "#000000"
-			return TOPIC_REFRESH_UPDATE_PREVIEW
+		var/new_marking = input(user, "Choose a marking to add:", CHARACTER_PREFERENCE_INPUT_TITLE, null) as null|anything in GLOB.body_marking_list - pref.body_markings
+		if(new_marking && CanUseTopic(user))
+			pref.body_markings[new_marking] = "#000000"
+		return TOPIC_REFRESH_UPDATE_PREVIEW
 	if(href_list["marking"])
 		if(CanUseTopic(user))
 			var/pos = text2num(href_list["marking"])

--- a/code/modules/organs/external/organ_icon.dm
+++ b/code/modules/organs/external/organ_icon.dm
@@ -197,6 +197,7 @@ var/global/list/limb_icon_cache = list()
 
 		mark_s.Blend(markings[M]["color"], mark_style.blend)
 		add_overlay(mark_s) //So when it's not on your body, it has icons
+		alpha = nonsolid ? 180 : 255
 		mob_icon.Blend(mark_s, ICON_OVERLAY) //So when it's on your body, it has icons
 	// EQUINOX EDIT END
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Let slimes get markings and make it semi-transparent just like their body!!!

![9u30eYhfuB](https://github.com/user-attachments/assets/5fa33bce-4c30-41cf-9f97-4d006f690ffb)

## Changelog
:cl:
tweak: Slimes (Aulvae) can have markings and they will inherit the opacity of slime body too. Make your slime muscleman of your dream.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
