### PR TITLE
CtrlShiftClick to split stacks, cable coil examine + 120 rods

### DIFF
--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -23,6 +23,9 @@
 	rand_max = 5
 	stacktype_alt = /obj/item/stack/rods
 
+/obj/item/stack/rods/full
+	amount = 120
+
 /obj/item/stack/rods/cyborg
 	name = "metal rod synthesizer"
 	desc = "A device that makes metal rods."

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -88,9 +88,10 @@
 /obj/item/stack/examine(mob/user)
 	if(..(user, 1))
 		if(!uses_charge)
-			to_chat(user, "There [src.amount == 1 ? "is" : "are"] [src.amount] [src.singular_name]\s in the stack.")
+			to_chat(user, SPAN_NOTICE("There [src.amount == 1 ? "is" : "are"] [src.amount] [src.singular_name]\s in the stack."))
+			to_chat(user, SPAN_NOTICE("Ctrl-Shift-Click to take a custom amount."))
 		else
-			to_chat(user, "There is enough charge for [get_amount()].")
+			to_chat(user, SPAN_NOTICE("There is enough charge for [get_amount()]."))
 
 /obj/item/stack/attack_self(mob/user as mob)
 	list_recipes(user)
@@ -399,6 +400,9 @@
 		..()
 	return
 
+/obj/item/stack/CtrlShiftClick(var/mob/living/user)
+	try_split(user)
+
 /obj/item/stack/attackby(obj/item/W as obj, mob/user as mob)
 	if (istype(W, /obj/item/stack))
 		var/obj/item/stack/S = W
@@ -415,16 +419,10 @@
 	else
 		return ..()
 
-//Verb to split stacks
-/obj/item/stack/verb/split_verb()
-	set src in view(1)
-	set name = "Split"
-	set category = "Object"
-
+// Function to split the stack, shared between verb and Ctrl Shift Click
+/obj/item/stack/proc/try_split(var/mob/usr)
 	if (!usr.IsAdvancedToolUser())
 		return
-
-
 
 	var/quantity = input(usr,
 	"This stack contains [amount]/[max_amount]. How many would you like to split off into a new stack?\n\
@@ -446,6 +444,14 @@
 		if (!(usr.put_in_hands(S)))
 			//If that fails, leave it beside the original stack
 			S.forceMove(get_turf(src))
+
+//Verb to split stacks
+/obj/item/stack/verb/split_verb()
+	set src in view(1)
+	set name = "Split"
+	set category = "Object"
+
+	try_split(usr)
 
 /obj/item/stack/get_item_cost(export)
 	return amount * ..()

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -616,18 +616,6 @@ obj/structure/cable/proc/cableColor(var/colorC)
 	else
 		w_class = ITEM_SIZE_SMALL
 
-/obj/item/stack/cable_coil/examine(mob/user)
-	if(get_dist(src, user) > 1)
-		return
-
-	if(get_amount() == 1)
-		to_chat(user, "A short piece of power cable.")
-	else if(get_amount() == 2)
-		to_chat(user, "A piece of power cable.")
-	else
-		to_chat(user, "A coil of power cable. There are [get_amount()] lengths of cable in the coil.")
-
-
 /obj/item/stack/cable_coil/verb/make_restraint()
 	set name = "Make Cable Restraints"
 	set category = "Object"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Add the ability to split a stack by using Ctrl Shift Click. (It is less used than alt click and was the one used on Paradise)
- Span Notice the stack amount and Ctrl Shift Click instructions.
- Desnowflake-ify the cable coil examine code. Loses a bit of flavor, but in exchange you get to see important information.
- Added a 120 rods for testing purpose

## Changelog
:cl:
tweak: You can now split a stack using Ctrl Shift Click instead of the verb (That no one notices, probably).
tweak: Cable coil no longer has a snowflake examine override.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
