### PR TITLE
Fixes Ammo Spam-Clicking

### DIFF
--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -239,18 +239,23 @@
 		insertCasing(C)
 	else if(istype(W, /obj/item/ammo_magazine))
 		var/obj/item/ammo_magazine/other = W
+		if(src.used_now)
+			to_chat(user, SPAN_NOTICE("You're already loading into [src]."))
+			return
 		if(!src.stored_ammo.len)
 			to_chat(user, SPAN_WARNING("There is no ammo in \the [src]!"))
 			return
 		if(other.stored_ammo.len >= other.max_ammo)
 			to_chat(user, SPAN_NOTICE("\The [other] is already full."))
 			return
+		src.used_now = TRUE
 		var/diff = FALSE
 		for(var/obj/item/ammo in src.stored_ammo)
 			if(other.stored_ammo.len < other.max_ammo && do_after(user, reload_delay/other.max_ammo, src) && other.insertCasing(removeCasing()))
 				diff = TRUE
 				continue
 			break
+		src.used_now = FALSE
 		if(diff)
 			to_chat(user, SPAN_NOTICE("You finish loading \the [other]. It now contains [other.stored_ammo.len] rounds, and \the [src] now contains [stored_ammo.len] rounds."))
 		else


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
Closes #142	
Prevents ammo box spam clicking to reload things faster. This solves a bug that causes ammo to be deleted if an ammobox is spamclicked because it tries to load more than it can and deletes the excess.
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
fix: Fixed ammo boxes eating bullets if spam clicked.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
