### PR TITLE
Allows slime people to toggle opacity with a perk

### DIFF
--- a/code/__DEFINES/perks.dm
+++ b/code/__DEFINES/perks.dm
@@ -161,6 +161,7 @@
 #define PERK_SLIMEMETH /datum/perk/racial/speed_boost
 #define PERK_SLIMEBRAIN /datum/perk/racial/slime_stat_boost/mental
 #define PERK_SLIMEBUFF /datum/perk/racial/slime_stat_boost/physical
+#define PERK_SLIMEOPAQUE /datum/perk/racial/slime_opaque
 
 //////////////
 //Core Perks//

--- a/code/datums/perks/racial.dm
+++ b/code/datums/perks/racial.dm
@@ -760,6 +760,9 @@
 		for(var/obj/item/organ/external/E in H.organs)
 			was_nonsolid = E.nonsolid
 			E.nonsolid = !E.nonsolid
+		if(world.time < cooldown_time)
+			to_chat(usr, SPAN_NOTICE("You can't change your body's opacity again this quickly!"))
+			return FALSE
 		cooldown_time = world.time + 1 MINUTES // Short cooldown to prevent spamming as it can be potentially expensive
 		H.alpha = was_nonsolid ? 255 : 210 // Yeah uh, the organ code doesn't really contribute to the overall alpha lmao
 		H.update_body()

--- a/code/datums/perks/racial.dm
+++ b/code/datums/perks/racial.dm
@@ -746,28 +746,24 @@
 	holder.nutrition -= nutrition_cost
 	holder.reagents.add_reagent("slime_speed", 5)
 
-/* This is the old code for this perk, it does not work but it's left for postereity. Feel free to remove if you please - CDB
-/datum/perk/racial/limb_regen
-	name = "Gelatinous Regeneration"
-	desc = "Spend nutrition to regenerate lost limbs, albeit without fully fixing your injuries."
-	var/cooldown = 30 MINUTES
-	passivePerk = FALSE
-	var/nutrition_cost = 300
+/datum/perk/racial/slime_opaque
+	name = "Toggle Opacity"
+	desc = "Use your ability to turn your body opaque or transparent again"
 
-/datum/perk/racial/limb_regen/activate()
-	if(world.time < cooldown_time)
-		to_chat(usr, SPAN_NOTICE("You can't regenerate again so soon!"))
-		return FALSE
-	cooldown_time = world.time + cooldown
-	holder.nutrition -= nutrition_cost
-	for(var/obj/item/organ/external/current_organ in holder.organs) //grab the current brute/burn of the limb, then re-apply half of it after rejuvenating OR subtract ten, whichever is lower
-		var/old_brute = current_organ.brute_dam
-		var/old_burn = current_organ.burn_dam
-		if(!(current_organ == BP_HEAD))
-			current_organ.replaced()
-		current_organ.rejuvenate()
-		current_organ.brute_dam = max(0, min((old_brute / 2), (old_brute - 10)))
-		current_organ.burn_dam = max(0, min((old_burn / 2), (old_burn - 10)))*/
+	passivePerk = FALSE
+	icon_state = "gelatinousbiology" // No icon so reusing it
+
+/datum/perk/racial/slime_opaque/activate()
+	if(ishuman(holder))
+		var/mob/living/carbon/human/H = holder
+		var/was_nonsolid // They have multiple organs but boldly assume that it will not go out of sync, yet.
+		for(var/obj/item/organ/external/E in H.organs)
+			was_nonsolid = E.nonsolid
+			E.nonsolid = !E.nonsolid
+		cooldown_time = world.time + 1 MINUTES // Short cooldown to prevent spamming as it can be potentially expensive
+		H.alpha = was_nonsolid ? 255 : 210 // Yeah uh, the organ code doesn't really contribute to the overall alpha lmao
+		H.update_body()
+		H.visible_message(SPAN_NOTICE("[H]'s body turns [was_nonsolid ? "opaque" : "translucent"]!"))
 
 /datum/perk/racial/slime_metabolism
 	name = "Gelatinous Biology"

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -1158,7 +1158,7 @@
 		BP_R_LEG =  new /datum/organ_description/leg/right/slime
 	)
 
-	perks = list(PERK_SLIMEMETH, PERK_SLIMEBRAIN, PERK_SLIMEBUFF, PERK_LIMB_REGEN, PERK_SLIMEBODY)
+	perks = list(PERK_SLIMEMETH, PERK_SLIMEBRAIN, PERK_SLIMEBUFF, PERK_LIMB_REGEN, PERK_SLIMEOPAQUE, PERK_SLIMEBODY)
 
 /datum/species/slime/get_bodytype()
 	return "Aulvae"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Slime people now gain a perk called "Toggle Opacity" that let them toggle their opacity every minute

## Changelog
:cl:
tweak: Aulvae (Slime people) can toggle opacity now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
