### PR TITLE
Port VRStation #8021 Character Preview

### DIFF
--- a/code/_global_vars/mapping.dm
+++ b/code/_global_vars/mapping.dm
@@ -1,2 +1,9 @@
 // AREA LIST //
 GLOBAL_LIST_EMPTY(map_areas)
+
+GLOBAL_LIST_INIT(cardinals, list(
+	NORTH,
+	SOUTH,
+	EAST,
+	WEST,
+))

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -133,3 +133,5 @@
 	var/last_completed_asset_job = 0
 
 	var/obj/screen/click_catcher/void
+
+	var/list/char_render_holders

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -357,6 +357,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	clients -= src
 	directory -= ckey
 	log_access("Logout: [key_name(src)]")
+	QDEL_LIST_ASSOC_VAL(char_render_holders)
 	if(holder)
 		holder.owner = null
 		admins -= src

--- a/code/modules/client/preference_setup/augmentation/01_modifications.dm
+++ b/code/modules/client/preference_setup/augmentation/01_modifications.dm
@@ -163,6 +163,4 @@
 			pref.check_child_modifications(pref.current_organ)
 		return TOPIC_REFRESH_UPDATE_PREVIEW
 
-		return TOPIC_REFRESH
-
 	return ..()

--- a/code/modules/client/preference_setup/augmentation/01_modifications.dm
+++ b/code/modules/client/preference_setup/augmentation/01_modifications.dm
@@ -31,23 +31,6 @@
 
 
 /datum/category_item/player_setup_item/augmentation/modifications/content(var/mob/user)
-	if(!pref.preview_icon)
-		pref.update_preview_icon(naked = TRUE)
-	if ((pref.preview_dir== EAST) && (!pref.preview_east))
-		pref.mannequin = get_mannequin(pref.client_ckey)
-		pref.mannequin.delete_inventory(TRUE)
-		if(SSticker.current_state > GAME_STATE_STARTUP)
-			pref.dress_preview_mob(pref.mannequin, TRUE)
-		pref.mannequin.dir = EAST
-		pref.preview_east = getFlatIcon(pref.mannequin, EAST)
-		pref.preview_east.Scale(pref.preview_east.Width() * 2, pref.preview_east.Height() * 2)
-		user << browse_rsc(pref.preview_east, "new_previewicon[EAST].png")
-
-	if(pref.preview_north && pref.preview_south  && pref.preview_west)
-		user << browse_rsc(pref.preview_north, "new_previewicon[NORTH].png")
-		user << browse_rsc(pref.preview_south, "new_previewicon[SOUTH].png")
-		user << browse_rsc(pref.preview_west, "new_previewicon[WEST].png")
-
 	var/dat = list()
 
 	dat += "<style>div.block{margin: 3px 0px;padding: 4px 0px;}"
@@ -55,7 +38,7 @@
 	dat += "a.Organs_active {background: #cc5555;}</style>"
 
 	dat +=  "<script language='javascript'> [js_byjax] function set(param, value) {window.location='?src=\ref[src];'+param+'='+value;}</script>"
-	dat += "<table style='max-height:400px;height:410px; margin-left:250px; margin-right:250px'>"
+	dat += "<table style='max-height:400px;height:410px; margin-left:24px; margin-right:24px'>"
 	dat += "<tr style='vertical-align:top'>"
 	if(pref.modifications_allowed())
 		dat += "<td><div style='max-width:230px;width:230px;height:100%;overflow-y:auto;border-right:1px solid;padding:3px'>"
@@ -80,8 +63,9 @@
 			dat += "<a href='?src=\ref[src];color=[organ]'><span class='color_holder_box' style='background-color:[pref.modifications_colors[organ]]'></span></a>"
 		dat += "<br>[disp_name]<br>"
 
-	dat += "</td><td style='width:80px;'><center><img src=new_previewicon[pref.preview_dir].png height=64 width=64>"
-	dat += "<br><center><a href='?src=\ref[src];rotate=right'>&lt;&lt;</a> <a href='?src=\ref[src];rotate=left'>&gt;&gt;</a></center></td>"
+	// This take place of the original preview icon
+	dat += "</td><td style='width:80px;'>"
+	dat += "<br><center></center></td>"
 	dat += "<td style='width:115px; text-align:left'>"
 
 	for(var/organ in pref.l_organs)
@@ -178,21 +162,6 @@
 			pref.modifications_data[pref.current_organ] = mod
 			pref.check_child_modifications(pref.current_organ)
 		return TOPIC_REFRESH_UPDATE_PREVIEW
-
-	else if(href_list["rotate"])
-		if(href_list["rotate"] == "right")
-			pref.preview_dir = turn(pref.preview_dir,-90)
-		else
-			pref.preview_dir = turn(pref.preview_dir,90)
-		if ((pref.preview_dir == EAST) && (!pref.preview_east))
-			pref.mannequin = get_mannequin(pref.client_ckey)
-			pref.mannequin.delete_inventory(TRUE)
-			if(SSticker.current_state > GAME_STATE_STARTUP)
-				pref.dress_preview_mob(pref.mannequin, TRUE)
-			pref.mannequin.dir = EAST
-			pref.preview_east = getFlatIcon(pref.mannequin, EAST)
-			pref.preview_east.Scale(pref.preview_east.Width() * 2, pref.preview_east.Height() * 2)
-			user << browse_rsc(pref.preview_east, "new_previewicon[EAST].png")
 
 		return TOPIC_REFRESH
 

--- a/code/modules/client/preference_setup/general/02_body.dm
+++ b/code/modules/client/preference_setup/general/02_body.dm
@@ -38,8 +38,7 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 	from_file(S["skin_base"], pref.s_base)
 	from_file(S["hair_style_name"], pref.h_style)
 	from_file(S["facial_style_name"], pref.f_style)
-	if (!pref.generating_preview)
-		pref.preview_icon = null
+	pref.update_preview_icon()
 	from_file(S["bgstate"], pref.bgstate)
 	from_file(S["eyes_color"], pref.eyes_color)
 	from_file(S["skin_color"], pref.skin_color)
@@ -102,11 +101,6 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 		pref.bgstate = "black"
 
 /datum/category_item/player_setup_item/physical/body/content(var/mob/user)
-	if(!pref.preview_icon)
-		pref.update_preview_icon()
-	if (pref.preview_icon) // failsafe, if the icon fails to render for whatever reason we at least have our customization options
-		user << browse_rsc(pref.preview_icon, "previewicon.png")
-
 	var/datum/species_form/mob_species_form = GLOB.all_species_form_list[pref.species_form]
 	. += "<style>span.color_holder_box{display: inline-block; width: 20px; height: 8px; border:1px solid #000; padding: 0px;}</style>"
 	. += "<hr>"
@@ -159,7 +153,6 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 	. += "<b>Scale:</b> <a href='?src=\ref[src];scale_effect=1'>[pref.scale_effect+100]%</a><br>"
 
 	. += "</td><td style = 'text-align:center;' width = 35%><b>Preview</b><br>"
-	. += "<div style ='padding-bottom:-2px;' class='statusDisplay'><img src=previewicon.png width=[pref.preview_icon.Width()] height=[pref.preview_icon.Height()]></div>"
 	. += "<br><a href='?src=\ref[src];cycle_bg=1'>Cycle background</a>"
 	. += "<br><a href='?src=\ref[src];toggle_preview_value=[EQUIP_PREVIEW_LOADOUT]'>[pref.equip_preview_mob & EQUIP_PREVIEW_LOADOUT ? "Hide loadout" : "Show loadout"]</a>"
 	. += "<br><a href='?src=\ref[src];toggle_preview_value=[EQUIP_PREVIEW_JOB]'>[pref.equip_preview_mob & EQUIP_PREVIEW_JOB ? "Hide job gear" : "Show job gear"]</a>"

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -116,12 +116,6 @@ var/list/gear_datums = list()
 			pref.gear_list[index] = list()
 
 /datum/category_item/player_setup_item/loadout/content(var/mob/user)
-	if(!pref.preview_icon)
-		pref.update_preview_icon()
-	if(pref.preview_north && pref.preview_south && pref.preview_west)
-		user << browse_rsc(pref.preview_north, "new_previewicon[NORTH].png")
-		user << browse_rsc(pref.preview_south, "new_previewicon[SOUTH].png")
-		user << browse_rsc(pref.preview_west, "new_previewicon[WEST].png")
 	. = list()
 	var/total_cost = 0
 	var/list/gears = pref.gear_list[pref.gear_slot]
@@ -166,8 +160,6 @@ var/list/gear_datums = list()
 				. += " <a href='?src=\ref[src];select_category=[category]'><font color = '#e67300'>[category] - [category_cost]</font></a> "
 			else
 				. += " <a href='?src=\ref[src];select_category=[category]'>[category] - 0</a> "
-	. += "<div class='statusDisplay' style = 'max-width: 192px; clear:both;'><img src=new_previewicon[SOUTH].png width=64 height=64><img src=new_previewicon[WEST].png width=64 height=64><img src=new_previewicon[NORTH].png width=64 height=64></div>"
-	. += "</b></center></td></tr>"
 
 	var/datum/loadout_category/LC = loadout_categories[current_tab]
 	. += "<tr><td colspan=3><hr></td></tr>"

--- a/code/modules/client/preference_setup/preference_setup.dm
+++ b/code/modules/client/preference_setup/preference_setup.dm
@@ -271,8 +271,8 @@ var/const/CHARACTER_PREFERENCE_INPUT_TITLE = "Character Preference"
 	if(!pref_mob || !pref_mob.client)
 		return 1
 
-	if(. & TOPIC_UPDATE_PREVIEW && (!pref_mob.client.prefs.generating_preview))
-		pref_mob.client.prefs.preview_icon = null
+	if(. & TOPIC_UPDATE_PREVIEW)
+		pref_mob.client.prefs.update_preview_icon()
 	if(. & TOPIC_REFRESH)
 		pref_mob.client.prefs.ShowChoices(usr)
 

--- a/code/modules/client/preference_setup/preview.dm
+++ b/code/modules/client/preference_setup/preview.dm
@@ -1,56 +1,13 @@
-datum/preferences
-	var/icon/preview_icon  = null
-	var/icon/preview_south = null
-	var/icon/preview_north = null
-	var/icon/preview_east  = null
-	var/icon/preview_west  = null
-	var/preview_dir = SOUTH	//for augmentation
+/datum/preferences
 	var/mob/living/carbon/human/dummy/mannequin/mannequin = null
-	var/generating_preview = FALSE
 
-datum/preferences/proc/update_preview_icon(var/naked = FALSE)
-	if (generating_preview)
-		return
-	generating_preview = TRUE
-
+/datum/preferences/proc/update_preview_icon(var/naked = FALSE)
 	mannequin = get_mannequin(client_ckey)
 	mannequin.delete_inventory(TRUE)
-	preview_icon = icon('icons/effects/96x64.dmi', bgstate)
 
 //Equinox edit - makes it so that you can preview your character edits when the server is still initing
 	dress_preview_mob(mannequin, naked)
 
-	/*
-	mannequin.dir = EAST
-	preview_east = getFlatIcon(mannequin, EAST)
-	*/
-	preview_east = null
-
-	mannequin.dir = WEST
-	var/icon/stamp = getFlatIcon(mannequin, WEST)
-	CHECK_TICK
-	preview_icon.Blend(stamp, ICON_OVERLAY, (preview_icon.Width()/6*1) - (stamp.Width()/2) + 2, preview_icon.Height()/4*1 + 1)
-	preview_west = stamp
-
-	mannequin.dir = NORTH
-	stamp = getFlatIcon(mannequin, NORTH)
-	CHECK_TICK
-	preview_icon.Blend(stamp, ICON_OVERLAY, (preview_icon.Width()/6*3) - (stamp.Width()/2) + 2, preview_icon.Height()/4*2 + 1)
-	preview_north = stamp
-
-	mannequin.dir = SOUTH
-	stamp = getFlatIcon(mannequin, SOUTH)
-	CHECK_TICK
-	preview_icon.Blend(stamp, ICON_OVERLAY, (preview_icon.Width()/6*5) - (stamp.Width()/2) + 2, preview_icon.Height()/4*0 + 1)
-	preview_south = stamp
-
-	// Scaling here to prevent blurring in the browser.
-	//preview_east.Scale(preview_east.Width() * 2, preview_east.Height() * 2)
-	preview_west.Scale(preview_west.Width() * 2, preview_west.Height() * 2)
-	preview_north.Scale(preview_north.Width() * 2, preview_north.Height() * 2)
-	preview_south.Scale(preview_south.Width() * 2, preview_south.Height() * 2)
-	preview_icon.Scale(preview_icon.Width() * 2, preview_icon.Height() * 2)
-
-	generating_preview = FALSE
+	update_character_previews(new /mutable_appearance(mannequin))
 
 	return mannequin.icon

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -62,12 +62,14 @@
 	if(slot != SAVE_RESET)
 		S.cd = GLOB.maps_data.character_load_path(S, slot)
 		player_setup.load_character(S)
+		clear_character_previews() //Forces the character editor to refresh everything, preventing characters from getting their body markings (visually) mixed up
+
 	else
 		player_setup.load_character(S)
+		clear_character_previews() //Forces the character editor to refresh everything, preventing characters from getting their body markings (visually) mixed up
 		S.cd = GLOB.maps_data.character_load_path(S, default_slot)
 
 	loaded_character = S
-	categoriesChanged = "All"	//Forces the character editor to refresh everything, preventing characters from getting their body markings (visually) mixed up
 
 	return 1
 

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -70,6 +70,7 @@
 		S.cd = GLOB.maps_data.character_load_path(S, default_slot)
 
 	loaded_character = S
+	categoriesChanged = "All"	//Forces the character editor to refresh everything, preventing characters from getting their body markings (visually) mixed up
 
 	return 1
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Port the way more performant character preview from VRStation that uses mutable appearance. This cut down the amount of .Blend call from 1270 to 1150 after shifting markings around 5 times on a character with 2 markings. Avoids the expensive getFlatIcon call and reduce the rscfile calls. 

This currently don't seems to result in significant performance savings - but will become much more important when we move over to a mutable appearance-based system akin to TG where getFlatIcon become proportionally more expensive.

![image](https://github.com/user-attachments/assets/c0af0cca-42a5-4c6d-a9ac-f431610e8c74)
![image](https://github.com/user-attachments/assets/fb40ce77-79ae-4259-82bf-6b5f561b162e)
![image](https://github.com/user-attachments/assets/537e7135-77c6-4657-910d-ec32af078372)

	
## Changelog
:cl:
tweak: Character preview now shows in a separate window to the right and should be slightly more performant.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
