### PR TITLE
AI Performance #78 Revival

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -459,7 +459,7 @@
 	if(!can_open(forced))
 		return
 	operating = TRUE
-	if(usr.client && istype(usr, /mob/living/carbon/human)) // Don't let mob activate themselves
+	if(usr && usr.client && istype(usr, /mob/living/carbon/human)) // Don't let mob activate themselves
 		activate_mobs_in_range(src, 10)
 
 	set_opacity(0)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -459,7 +459,8 @@
 	if(!can_open(forced))
 		return
 	operating = TRUE
-	activate_mobs_in_range(src, 10)
+	if(usr.client && istype(usr, /mob/living/carbon/human)) // Don't let mob activate themselves
+		activate_mobs_in_range(src, 10)
 
 	set_opacity(0)
 	if(istype(src, /obj/machinery/door/airlock/multi_tile/metal))

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -11,9 +11,9 @@
 			else
 				if(check_surrounding_area(7))
 					activate_ai()
-					life_cycles_before_scan = 29 //So it doesn't fall asleep just to wake up the next tick
+					life_cycles_before_scan = 29 / rand(0.75, 1.25) //So it doesn't fall asleep just to wake up the next tick
 				else
-					life_cycles_before_scan = 240
+					life_cycles_before_scan = 240 / rand(0.75, 1.25)
 
 			if(life_cycles_before_sleep)
 				life_cycles_before_sleep--

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -14,7 +14,7 @@
 	var/life_cycles_before_scan = 360
 
 	var/stasis = FALSE
-	var/AI_inactive = FALSE
+	var/AI_inactive = TRUE // Set it to inactive by default to reduce CPU load by A LOT. Removes infighting before players are there but who care.
 
 	var/inventory_shown = 1
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Revives #78 with the changes that I believe is helpful for performance

This default all mob's AI_inactive to true. 

On local server, mobs MS peaked around 110 - 120 MS compare to 500 - 700 MS peak in like 5 - 10 minutes of testing.

**EDIT:**
- On live server, defaulting AI to inactive don't seems to have a significant impact after 30 - 50 minutes.
- Incorporated part of the changes for door not chain activating mobs + random sleep cycle to see if it performs better. 

**Why this is good for the game**
Currently on Sojourn codebase, there's two main sources of lag: 
- Mobs - there's over 4 - 5k mobs on the map which generate constant source of lag
- Character Creation - Eris's character creation system is extremely inefficient, and markings make it 3 - 10 times worse. 

This one should solve or at least greatly mitigate the former.

## Changelog
:cl:
tweak: All mobs default to having their AI inactive unless otherwise activated.
tweak: Mobs can no longer activate themselves by opening door.
tweak: Mobs now sleep at random interval to reduce peak load.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
