### PR TITLE
Mining Improvements

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1223,6 +1223,26 @@ proc/is_hot(obj/item/W as obj)
 		if(NORTHWEST)
 			return SOUTHEAST
 
+// Get neighboring cardinal / ordinal direction. Return 2
+/proc/get_neighbor_directions(var/dir)
+	switch(dir)
+		if(NORTH)
+			return list(NORTHEAST, NORTHWEST)
+		if(NORTHEAST)
+			return list(NORTH, EAST)
+		if(EAST)
+			return list(NORTHEAST, SOUTHEAST)
+		if(SOUTHEAST)
+			return list(EAST, SOUTH)
+		if(SOUTH)
+			return list(SOUTHEAST, SOUTHWEST)
+		if(SOUTHWEST)
+			return list(SOUTH, WEST)
+		if(WEST)
+			return list(SOUTHWEST, NORTHWEST)
+		if(NORTHWEST)
+			return list(WEST, NORTH)
+
 /*
 Checks if that loc and dir has a item on the wall
 */

--- a/code/game/mecha/equipment/tools/mining_tools.dm
+++ b/code/game/mecha/equipment/tools/mining_tools.dm
@@ -18,7 +18,10 @@
 	required_type = list(/obj/mecha/working, /obj/mecha/combat, /obj/mecha/medical)
 
 /obj/item/mecha_parts/mecha_equipment/tool/drill/action(atom/T, mob/living/user)
-	attack_object(T, user) // drill has nothing special to do, just drilling
+	attack_object(T, user) // Drill the target tile
+	for(var/turf/simulated/mineral/M in range(chassis, 1))
+		if(get_dir(chassis, M) in get_neighbor_directions(get_dir(chassis, T)))
+			attack_object(M, user) // And the two neighboring one
 
 /obj/item/mecha_parts/mecha_equipment/tool/drill/attack_object(obj/T, mob/living/user) // attack_object override for all of the drill's fancy interactions after action()
 	..() // strike the earth
@@ -27,8 +30,7 @@
 		var/obj/structure/ore_box/ore_box = locate(/obj/structure/ore_box) in chassis.cargo
 		if(ore_box)
 			for(var/obj/item/stack/ore/ore in range(chassis,1))
-				if(get_dir(chassis,ore)&chassis.dir)
-					ore.Move(ore_box)
+				ore.Move(ore_box)
 
 	return 1
 

--- a/code/game/mecha/equipment/tools/mining_tools.dm
+++ b/code/game/mecha/equipment/tools/mining_tools.dm
@@ -18,7 +18,7 @@
 	required_type = list(/obj/mecha/working, /obj/mecha/combat, /obj/mecha/medical)
 
 /obj/item/mecha_parts/mecha_equipment/tool/drill/action(atom/T, mob/living/user)
-	attack_object(T,user) // drill has nothing special to do, just drilling
+	attack_object(T, user) // drill has nothing special to do, just drilling
 
 /obj/item/mecha_parts/mecha_equipment/tool/drill/attack_object(obj/T, mob/living/user) // attack_object override for all of the drill's fancy interactions after action()
 	..() // strike the earth
@@ -41,18 +41,3 @@
 	equip_cooldown = 10 // 3 diamonds for 3x the speed!
 	force = 40
 	tool_qualities = list(QUALITY_DIGGING = 90)
-
-/obj/item/mecha_parts/mecha_equipment/tool/drill/diamonddrill/action(atom/T, mob/living/user)
-	attack_object(T,user) // drill has nothing special to do, just drilling
-
-/obj/item/mecha_parts/mecha_equipment/tool/drill/diamonddrill/attack_object(obj/T, mob/living/user) // attack_object override for all of the drill's fancy interactions after action()
-	..() // strike the earth
-
-	if(locate(/obj/item/mecha_parts/mecha_equipment/tool/hydraulic_clamp) in chassis.equipment) // load ore if any is nearby after striking something
-		var/obj/structure/ore_box/ore_box = locate(/obj/structure/ore_box) in chassis.cargo
-		if(ore_box)
-			for(var/obj/item/stack/ore/ore in range(chassis,1))
-				if(get_dir(chassis,ore)&chassis.dir)
-					ore.Move(ore_box)
-
-	return 1

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -89,10 +89,14 @@
 	has_resources = 1
 
 /turf/simulated/mineral/Initialize()
-	.=..()
+	. = ..()
 	icon_state = "rock[rand(0,4)]"
 	spawn(0)
 		MineralSpread()
+
+/turf/simulated/mineral/examine()
+	. = ..()
+	to_chat(usr, SPAN_NOTICE("You can mine it by walking into it with a digging tool in your active hand. Or in an exosuit with an active drill."))
 
 /turf/simulated/mineral/can_build_cable()
 	return !density
@@ -127,14 +131,10 @@
 	. = ..()
 	if(ishuman(AM))
 		var/mob/living/carbon/human/H = AM
-		if(istype(H.l_hand,/obj/item))
-			var/obj/item/I = H.l_hand
-			if((QUALITY_DIGGING in I.tool_qualities) && (!H.hand))
-				attackby(I,H)
-		if(istype(H.r_hand,/obj/item))
-			var/obj/item/I = H.r_hand
-			if((QUALITY_DIGGING in I.tool_qualities) && (H.hand))
-				attackby(I,H)
+		var/obj/item/W = H.get_active_hand()
+		if(istype(W,/obj/item))
+			if(QUALITY_DIGGING in W.tool_qualities)
+				attackby(W,H)
 
 	else if(isrobot(AM))
 		var/mob/living/silicon/robot/R = AM
@@ -145,8 +145,10 @@
 
 	else if(istype(AM,/obj/mecha))
 		var/obj/mecha/M = AM
-		if(istype(M.selected,/obj/item/mecha_parts/mecha_equipment/tool/drill))
-			M.selected.action(src)
+		var/mob/living/user = M.occupant // Need to pass it in for stats, also means mech user skill technically matter, at least for mining
+		// i.e. 30 ROB = instant mining with default drill
+		if(istype(M.selected,/obj/item/mecha_parts/mecha_equipment/tool/drill) && M.occupant)
+			M.selected.action(src, user) // Can't figure out how to 3x1 this later
 
 /turf/simulated/mineral/proc/MineralSpread()
 	if(mineral && mineral.spread)
@@ -170,6 +172,12 @@
 
 //Not even going to touch this pile of spaghetti
 /turf/simulated/mineral/attackby(obj/item/I, mob/living/user)
+	// Yes this is spaghetti but short of an entire rewrite of mine_turf attackby this is the only way to stop mining turf
+	if(istype(I, /obj/item/mecha_parts/mecha_equipment/))
+		var/obj/item/mecha_parts/mecha_equipment/M = I
+		if(!M.chassis)
+			to_chat(user, SPAN_DANGER("You cannot use this tool by hand!"))
+			return
 
 	var/tool_type = I.get_tool_type(user, list(QUALITY_DIGGING, QUALITY_EXCAVATION), src, CB = CALLBACK(src,PROC_REF(check_radial_dig)))
 	switch(tool_type)
@@ -321,7 +329,7 @@
 		var/obj/item/device/measuring_tape/P = I
 		user.visible_message(SPAN_NOTICE("\The [user] extends [P] towards [src]."),SPAN_NOTICE("You extend [P] towards [src]."))
 		if(do_after(user,25, src))
-			to_chat(user, SPAN_NOTICE("\icon[P] [src] has been excavated to a depth of [2*excavation_level]cm."))
+			to_chat(user, SPAN_NOTICE("\icon[P] [src] has been excavated to a depth of [excavation_level]cm."))
 		return
 
 	else

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -174,6 +174,7 @@
 /turf/simulated/mineral/attackby(obj/item/I, mob/living/user)
 	// Yes this is spaghetti but short of an entire rewrite of mine_turf attackby this is the only way to stop mining turf
 	if(istype(I, /obj/item/mecha_parts/mecha_equipment/))
+		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN) // Short cooldown on mech to make it not overwhelmingly quick vs foot mining
 		var/obj/item/mecha_parts/mecha_equipment/M = I
 		if(!M.chassis)
 			to_chat(user, SPAN_DANGER("You cannot use this tool by hand!"))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Some mining improvements:
- Fixed runtime with mech bumping and let you bump mine. Mech drill now mine 3x1.
- Can't use mech drills on hand anymore (It was OP)
- You can now bump mine with anything in your ACTIVE hand instead of your inactive hand
- Measuring Tape no longer shows 2x the actual excavation level as your excavation level. Why, just why?

## Changelog
:cl:
fix: Mech bump mining actually works
tweak: Mecha drill now mine in a 3x1 area. Or 2x1 if the tile is not a neighbor (duh). It sets a 8 TICK cooldown (same as a normal attack action) before the next click so you cannot obliterate the cave at lightspeed.
tweak: You cannot use mecha drill in your hand anymore
tweak: You can bump mine with things in your active hand. Also examining a mineral turf will tell you you can actually bump mine this way. (Clicking is still faster if you can insta mine)
tweak: Measuring tape no longer show 2x the excavation level because fuck you that's why?
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
