### PR TITLE
Enable Railing Buckling

### DIFF
--- a/code/game/objects/structures/railing.dm
+++ b/code/game/objects/structures/railing.dm
@@ -17,6 +17,8 @@
 	var/reinforced = FALSE
 	var/reinforcement_security = 0 // extra health from being reinforced, hardcoded to 40 on add
 	var/icon_modifier = ""	//adds string to icon path for color variations
+	can_buckle = TRUE //Equinox Edit/Addition
+	buckle_require_restraints = 1 //Equinox Edit/Addition. Yes, It needs to be 1, not TRUE for some fuck reason.
 
 /obj/structure/railing/grey
 	name = "grey railing"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Simply enables the ability to buckle restrained people to railings.
Useful for when security needs a detainee to hold still (In good faith :> Reminder you can struggle out IIRC) for a myriad of reasons (Needing to clear mobs without risking the prisoner, needing to clear a path, Holding someone still so they will listen to you. **_Other things_**)

## Changelog
:cl:
tweak: Enables can_buckle and buckle_require_restraints for railings. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
